### PR TITLE
Slice 5: oversized turn handling at Discord layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "smoketest:remember": "tsx scripts/test-remember.ts",
     "smoketest:sentinel": "tsx scripts/test-sentinel-parser.ts",
     "smoketest:truncation": "tsx scripts/test-truncation.ts",
-    "smoketest:qwen-tools": "tsx scripts/qwen-tool-smoketest.ts"
+    "smoketest:qwen-tools": "tsx scripts/qwen-tool-smoketest.ts",
+    "smoketest:oversize-turn": "tsx scripts/test-oversize-turn.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/test-oversize-turn.ts
+++ b/scripts/test-oversize-turn.ts
@@ -20,6 +20,7 @@ import {
   BotInstance,
   TURN_BUDGET,
   evaluateTurnSize,
+  splitLeadingAttachmentBlocks,
 } from "../src/bot-instance.js";
 import { estimateTokens } from "../src/token-estimate.js";
 
@@ -310,6 +311,120 @@ sect("7. attachments included in size measurement");
     "human + huge attachment → reject_human (attachment counts)",
     d.kind === "reject_human",
   );
+}
+
+// -----------------------------------------------------------------------
+// 8. splitLeadingAttachmentBlocks — re-splitting the truncated body
+//    into (content, attachments) so the per-bot handler's invariant
+//    (directive detection runs on un-prepended content) survives the
+//    truncation path. Exercises the boundary check, mid-attachment
+//    truncation, and marker stripping.
+// -----------------------------------------------------------------------
+sect("8. splitLeadingAttachmentBlocks: clean two-attachment body");
+{
+  const body =
+    `[ATTACHMENT: a.md]\nalpha content\n[/ATTACHMENT]\n\n` +
+    `[ATTACHMENT: b.txt]\nbravo content\n[/ATTACHMENT]\n\n` +
+    `the prose lives here`;
+  const split = splitLeadingAttachmentBlocks(body);
+  check("returns 2 attachments", split.attachments.length === 2);
+  check("first attachment name", split.attachments[0]?.name === "a.md");
+  check(
+    "first attachment content (verbatim, no markers)",
+    split.attachments[0]?.content === "alpha content",
+  );
+  check("second attachment name", split.attachments[1]?.name === "b.txt");
+  check(
+    "second attachment content (verbatim)",
+    split.attachments[1]?.content === "bravo content",
+  );
+  check(
+    "trailing prose preserved",
+    split.content === "the prose lives here",
+  );
+}
+
+sect("9. splitLeadingAttachmentBlocks: no attachments → pass-through");
+{
+  const split = splitLeadingAttachmentBlocks("just some prose with no markers");
+  check("zero attachments", split.attachments.length === 0);
+  check(
+    "content equals input",
+    split.content === "just some prose with no markers",
+  );
+}
+
+sect("10. splitLeadingAttachmentBlocks: boundary check skips embedded close");
+{
+  // The attachment content itself contains "\n[/ATTACHMENT]" not followed
+  // by a "\n\n" or end-of-string boundary. The parser must skip it and
+  // find the REAL close that does have the boundary.
+  const body =
+    `[ATTACHMENT: doc.md]\n` +
+    `documenting the format: line ends with [/ATTACHMENT] tag here\n` +
+    `but the content continues here\n` +
+    `[/ATTACHMENT]\n\n` +
+    `prose tail`;
+  const split = splitLeadingAttachmentBlocks(body);
+  check("found exactly one attachment", split.attachments.length === 1);
+  check(
+    "attachment content includes the embedded false-positive line",
+    split.attachments[0]?.content.includes(
+      "documenting the format: line ends with [/ATTACHMENT] tag here",
+    ) ?? false,
+    `got: ${JSON.stringify(split.attachments[0]?.content?.slice(0, 200))}`,
+  );
+  check(
+    "attachment content includes the continuation line",
+    split.attachments[0]?.content.includes("but the content continues here") ??
+      false,
+  );
+  check("trailing prose extracted", split.content === "prose tail");
+}
+
+sect("11. splitLeadingAttachmentBlocks: truncation cut mid-attachment");
+{
+  // Simulate a truncated body that cut mid-attachment, with the
+  // TURN_TRUNCATE_MARKER appended to the whole. The marker MUST NOT end
+  // up inside attachment.content.
+  const body =
+    `[ATTACHMENT: huge.log]\n` +
+    `partial content that was cut off here` +
+    `\n\n[truncated]`;
+  const split = splitLeadingAttachmentBlocks(body);
+  check("one partial attachment recovered", split.attachments.length === 1);
+  check(
+    "partial attachment name preserved",
+    split.attachments[0]?.name === "huge.log",
+  );
+  check(
+    "marker NOT smuggled into attachment.content",
+    !(split.attachments[0]?.content.includes("[truncated]") ?? false),
+    `got: ${JSON.stringify(split.attachments[0]?.content?.slice(-60))}`,
+  );
+  check(
+    "partial content preserved up to the cut",
+    split.attachments[0]?.content === "partial content that was cut off here",
+  );
+  check(
+    "marker preserved as trailing content",
+    split.content.includes("[truncated]"),
+    `content: ${JSON.stringify(split.content)}`,
+  );
+}
+
+sect("12. splitLeadingAttachmentBlocks: end-of-string after close");
+{
+  // No trailing prose at all — body ends right after the last [/ATTACHMENT].
+  // The boundary check must accept end-of-string as a valid close.
+  const body = `[ATTACHMENT: only.md]\nlone attachment\n[/ATTACHMENT]`;
+  const split = splitLeadingAttachmentBlocks(body);
+  check("one attachment", split.attachments.length === 1);
+  check(
+    "attachment content extracted",
+    split.attachments[0]?.content === "lone attachment",
+  );
+  check("no trailing content", split.content === "");
 }
 
 // -----------------------------------------------------------------------

--- a/scripts/test-oversize-turn.ts
+++ b/scripts/test-oversize-turn.ts
@@ -105,12 +105,14 @@ sect("3. pure: bot + over → truncate_bot");
   check("kind is truncate_bot", d.kind === "truncate_bot");
   if (d.kind === "truncate_bot") {
     check("originalTokens matches input", d.originalTokens === tokens);
-    // Truncated body should sit at or under TURN_BUDGET * 0.9 = 19_800,
-    // with a small slack for the appended [truncated] marker.
+    // Truncated body should sit at or under TURN_BUDGET * 0.9 = 19_800.
+    // evaluateTurnSize appends the [truncated] marker INSIDE its scaling
+    // loop and re-measures the full emitted body each iteration, so the
+    // returned truncatedTokens is guaranteed to satisfy `<= cap` exactly.
     const cap = Math.floor(TURN_BUDGET * 0.9);
     check(
-      "truncatedTokens at or under 90% of TURN_BUDGET (+ small marker slack)",
-      d.truncatedTokens <= cap + 32,
+      "truncatedTokens at or under 90% of TURN_BUDGET",
+      d.truncatedTokens <= cap,
       `got: ${d.truncatedTokens}, cap: ${cap}`,
     );
     check(
@@ -218,8 +220,8 @@ sect("5. wiring: bot + over → warning posted, abort=false, body truncated");
   check("returns truncated body", result.body.length < big.length);
   check("truncated body has marker", result.body.includes("[truncated]"));
   check(
-    "truncated body fits within ~90% of TURN_BUDGET (+ marker slack)",
-    estimateTokens(result.body) <= Math.floor(TURN_BUDGET * 0.9) + 32,
+    "truncated body fits within 90% of TURN_BUDGET",
+    estimateTokens(result.body) <= Math.floor(TURN_BUDGET * 0.9),
   );
   check("exactly one warning sent", sent.length === 1);
   check(
@@ -384,32 +386,57 @@ sect("10. splitLeadingAttachmentBlocks: boundary check skips embedded close");
 
 sect("11. splitLeadingAttachmentBlocks: truncation cut mid-attachment");
 {
-  // Simulate a truncated body that cut mid-attachment, with the
-  // TURN_TRUNCATE_MARKER appended to the whole. The marker MUST NOT end
-  // up inside attachment.content.
+  // When truncation cuts mid-attachment (no boundary-flanked closing tag),
+  // the helper does NOT synthesise a parsed entry for the partial.
+  // Downstream renderers re-emit parsed attachments with a `[/ATTACHMENT]`
+  // closing tag that wasn't in the budgeted body, which would push the
+  // handler-visible prompt past the cap evaluateTurnSize already enforced.
+  // Instead the partial-attachment tail (including any trailing
+  // [truncated] marker) flows through verbatim as `content`.
   const body =
     `[ATTACHMENT: huge.log]\n` +
     `partial content that was cut off here` +
     `\n\n[truncated]`;
   const split = splitLeadingAttachmentBlocks(body);
-  check("one partial attachment recovered", split.attachments.length === 1);
   check(
-    "partial attachment name preserved",
-    split.attachments[0]?.name === "huge.log",
+    "no partial attachment synthesised",
+    split.attachments.length === 0,
+    `got: ${split.attachments.length}`,
   );
   check(
-    "marker NOT smuggled into attachment.content",
-    !(split.attachments[0]?.content.includes("[truncated]") ?? false),
-    `got: ${JSON.stringify(split.attachments[0]?.content?.slice(-60))}`,
+    "partial-attachment tail flows through as content (verbatim)",
+    split.content === body,
+    `got: ${JSON.stringify(split.content)}`,
+  );
+}
+
+sect("11b. splitLeadingAttachmentBlocks: closed attachment + mid-attachment cut");
+{
+  // A clean attachment closes, then truncation cuts inside the next one.
+  // The closed attachment IS recovered (its closing tag survived in the
+  // truncated body, so re-emitting adds no synthetic bytes). The partial
+  // tail still flows through as content.
+  const body =
+    `[ATTACHMENT: small.md]\nfirst content\n[/ATTACHMENT]\n\n` +
+    `[ATTACHMENT: huge.log]\nstart of huge\n\n[truncated]`;
+  const split = splitLeadingAttachmentBlocks(body);
+  check(
+    "first (closed) attachment recovered",
+    split.attachments.length === 1,
+    `got: ${split.attachments.length}`,
   );
   check(
-    "partial content preserved up to the cut",
-    split.attachments[0]?.content === "partial content that was cut off here",
+    "closed attachment name preserved",
+    split.attachments[0]?.name === "small.md",
   );
   check(
-    "marker preserved as trailing content",
-    split.content.includes("[truncated]"),
-    `content: ${JSON.stringify(split.content)}`,
+    "closed attachment content verbatim",
+    split.attachments[0]?.content === "first content",
+  );
+  check(
+    "partial-attachment tail flows through as content",
+    split.content === `[ATTACHMENT: huge.log]\nstart of huge\n\n[truncated]`,
+    `got: ${JSON.stringify(split.content)}`,
   );
 }
 

--- a/scripts/test-oversize-turn.ts
+++ b/scripts/test-oversize-turn.ts
@@ -1,0 +1,317 @@
+// Unit tests for oversized-turn handling at the Discord routing layer.
+//
+// We exercise both branches of the asymmetry from issue #5:
+//   - Human + over the per-turn token budget → reject in-channel and abort
+//     the per-bot handler.
+//   - Bot + over the per-turn token budget → truncate to ~90% of the budget,
+//     append a [truncated] marker, post a one-line warning, and continue.
+//
+// Two layers of coverage:
+//   1. Pure decision function `evaluateTurnSize(body, isBot)` exercised
+//      directly with synthetic strings.
+//   2. The `applyOversizeTurnPolicy` BotInstance method exercised against a
+//      stub channel so we can assert what would have been sent without
+//      booting Discord.
+//
+// Run: npx tsx scripts/test-oversize-turn.ts
+//      (also wired up as `npm run smoketest:oversize-turn`).
+
+import {
+  BotInstance,
+  TURN_BUDGET,
+  evaluateTurnSize,
+} from "../src/bot-instance.js";
+import { estimateTokens } from "../src/token-estimate.js";
+
+let failed = 0;
+let passed = 0;
+
+function check(label: string, cond: boolean, detail?: string) {
+  if (cond) {
+    console.log(`  PASS  ${label}`);
+    passed++;
+  } else {
+    console.log(`  FAIL  ${label}${detail ? " — " + detail : ""}`);
+    failed++;
+  }
+}
+
+function sect(name: string) {
+  console.log(`\n--- ${name} ---`);
+}
+
+// Build a string that estimates to roughly `targetTokens` tokens. cl100k_base
+// runs at ~1 token per ~3-4 chars for ASCII letters, so we generate a generous
+// repeating filler and verify with `estimateTokens` after the fact.
+function bodyOfTokens(targetTokens: number): string {
+  // Use a varied string so tiktoken doesn't collapse repeats into one token.
+  // "alpha bravo charlie delta echo " is ~30 chars, ~6 tokens.
+  const seed = "alpha bravo charlie delta echo ";
+  // Overshoot by 50% then trim back by char count if needed.
+  const repeats = Math.ceil((targetTokens / 6) * 1.5);
+  let s = seed.repeat(repeats);
+  // Walk back if we're too long (shouldn't happen, but safe).
+  while (estimateTokens(s) > targetTokens * 1.6 && s.length > 100) {
+    s = s.slice(0, Math.floor(s.length * 0.9));
+  }
+  return s;
+}
+
+// -----------------------------------------------------------------------
+// 1. Pure decision: small bodies pass through
+// -----------------------------------------------------------------------
+sect("1. pure: under-budget bodies pass through");
+{
+  const dHuman = evaluateTurnSize("hello world", false);
+  check("human under: ok", dHuman.kind === "ok");
+
+  const dBot = evaluateTurnSize("hello world", true);
+  check("bot under: ok", dBot.kind === "ok");
+
+  check(
+    "TURN_BUDGET is the documented 22_000",
+    TURN_BUDGET === 22_000,
+    `got: ${TURN_BUDGET}`,
+  );
+}
+
+// -----------------------------------------------------------------------
+// 2. Pure decision: human + over → reject_human with token counts
+// -----------------------------------------------------------------------
+sect("2. pure: human + over → reject_human");
+{
+  const big = bodyOfTokens(30_000);
+  const tokens = estimateTokens(big);
+  check("test fixture is over budget", tokens > TURN_BUDGET, `tokens=${tokens}`);
+
+  const d = evaluateTurnSize(big, false);
+  check("kind is reject_human", d.kind === "reject_human");
+  if (d.kind === "reject_human") {
+    check("reports token count", d.tokens === tokens, `got: ${d.tokens}`);
+    check("reports the limit", d.limit === TURN_BUDGET);
+  }
+}
+
+// -----------------------------------------------------------------------
+// 3. Pure decision: bot + over → truncate_bot with ~90% body
+// -----------------------------------------------------------------------
+sect("3. pure: bot + over → truncate_bot");
+{
+  const big = bodyOfTokens(30_000);
+  const tokens = estimateTokens(big);
+
+  const d = evaluateTurnSize(big, true);
+  check("kind is truncate_bot", d.kind === "truncate_bot");
+  if (d.kind === "truncate_bot") {
+    check("originalTokens matches input", d.originalTokens === tokens);
+    // Truncated body should sit at or under TURN_BUDGET * 0.9 = 19_800,
+    // with a small slack for the appended [truncated] marker.
+    const cap = Math.floor(TURN_BUDGET * 0.9);
+    check(
+      "truncatedTokens at or under 90% of TURN_BUDGET (+ small marker slack)",
+      d.truncatedTokens <= cap + 32,
+      `got: ${d.truncatedTokens}, cap: ${cap}`,
+    );
+    check(
+      "truncatedTokens still smaller than originalTokens",
+      d.truncatedTokens < d.originalTokens,
+    );
+    check(
+      "truncated body ends with [truncated] marker",
+      d.truncatedBody.includes("[truncated]"),
+      `tail: ${JSON.stringify(d.truncatedBody.slice(-40))}`,
+    );
+    check(
+      "truncated body shorter than original",
+      d.truncatedBody.length < big.length,
+    );
+  }
+}
+
+// -----------------------------------------------------------------------
+// 4. applyOversizeTurnPolicy — wiring layer: human-over path
+//    sends a one-line reply naming the limit and aborts the handler.
+// -----------------------------------------------------------------------
+sect("4. wiring: human + over → channel reply, abort=true");
+{
+  const handlerCalls: number[] = [];
+  const dummyHandler = async () => {
+    handlerCalls.push(1);
+  };
+  const bot = new BotInstance({
+    displayName: "TestBot",
+    knownBotIds: new Set<string>(),
+    handler: dummyHandler,
+    textMentionPattern: /@testbot/i,
+  });
+
+  interface SentPayload {
+    content?: string;
+  }
+  const sent: SentPayload[] = [];
+  const fakeChannel = {
+    send: async (arg: unknown) => {
+      if (typeof arg === "string") sent.push({ content: arg });
+      else sent.push(arg as SentPayload);
+    },
+  };
+
+  const big = bodyOfTokens(30_000);
+  const result = await bot.applyOversizeTurnPolicy(
+    fakeChannel as any,
+    big,
+    /* isBot */ false,
+    /* authorName */ "alice",
+  );
+
+  check("decision: abort=true", result.abort === true);
+  check("exactly one channel send", sent.length === 1, `sent=${sent.length}`);
+  check(
+    "reply mentions the limit (TURN_BUDGET)",
+    !!sent[0]?.content?.includes(String(TURN_BUDGET)),
+    `content: ${sent[0]?.content}`,
+  );
+  check(
+    "reply suggests chunk or attach",
+    !!sent[0]?.content && /chunk|attach|file/i.test(sent[0].content),
+    `content: ${sent[0]?.content}`,
+  );
+  check("handler is not invoked separately", handlerCalls.length === 0);
+}
+
+// -----------------------------------------------------------------------
+// 5. applyOversizeTurnPolicy — wiring layer: bot-over path
+//    truncates body, posts a warning, returns abort=false + truncated body.
+// -----------------------------------------------------------------------
+sect("5. wiring: bot + over → warning posted, abort=false, body truncated");
+{
+  const bot = new BotInstance({
+    displayName: "TestBot",
+    knownBotIds: new Set<string>(),
+    handler: async () => {},
+    textMentionPattern: /@testbot/i,
+  });
+
+  interface SentPayload {
+    content?: string;
+  }
+  const sent: SentPayload[] = [];
+  const fakeChannel = {
+    send: async (arg: unknown) => {
+      if (typeof arg === "string") sent.push({ content: arg });
+      else sent.push(arg as SentPayload);
+    },
+  };
+
+  const big = bodyOfTokens(30_000);
+  const originalTokens = estimateTokens(big);
+
+  const result = await bot.applyOversizeTurnPolicy(
+    fakeChannel as any,
+    big,
+    /* isBot */ true,
+    /* authorName */ "NemoClaw",
+  );
+
+  check("decision: abort=false (handler still runs)", result.abort === false);
+  check("returns truncated body", result.body.length < big.length);
+  check("truncated body has marker", result.body.includes("[truncated]"));
+  check(
+    "truncated body fits within ~90% of TURN_BUDGET (+ marker slack)",
+    estimateTokens(result.body) <= Math.floor(TURN_BUDGET * 0.9) + 32,
+  );
+  check("exactly one warning sent", sent.length === 1);
+  check(
+    "warning identifies the originating bot by name",
+    !!sent[0]?.content?.includes("NemoClaw"),
+    `content: ${sent[0]?.content}`,
+  );
+  check(
+    "warning includes the original token count",
+    !!sent[0]?.content?.includes(String(originalTokens)),
+    `content: ${sent[0]?.content}; expected: ${originalTokens}`,
+  );
+  check(
+    "warning includes the truncated-to token count",
+    !!sent[0]?.content?.includes(String(estimateTokens(result.body))),
+    `content: ${sent[0]?.content}`,
+  );
+  check(
+    "warning uses the truncated wording",
+    /trunc/i.test(sent[0]?.content ?? ""),
+    `content: ${sent[0]?.content}`,
+  );
+}
+
+// -----------------------------------------------------------------------
+// 6. applyOversizeTurnPolicy — under budget: noop pass-through
+// -----------------------------------------------------------------------
+sect("6. wiring: under budget → no send, body unchanged, abort=false");
+{
+  const bot = new BotInstance({
+    displayName: "TestBot",
+    knownBotIds: new Set<string>(),
+    handler: async () => {},
+    textMentionPattern: /@testbot/i,
+  });
+
+  const sent: any[] = [];
+  const fakeChannel = {
+    send: async (arg: unknown) => {
+      sent.push(arg);
+    },
+  };
+
+  const small = "small body, definitely under 22k tokens";
+  const r1 = await bot.applyOversizeTurnPolicy(
+    fakeChannel as any,
+    small,
+    false,
+    "alice",
+  );
+  check("no channel send for human under", sent.length === 0);
+  check("abort=false", r1.abort === false);
+  check("body untouched", r1.body === small);
+
+  const r2 = await bot.applyOversizeTurnPolicy(
+    fakeChannel as any,
+    small,
+    true,
+    "OtherBot",
+  );
+  check("no channel send for bot under", sent.length === 0);
+  check("abort=false (bot under)", r2.abort === false);
+  check("body untouched (bot under)", r2.body === small);
+}
+
+// -----------------------------------------------------------------------
+// 7. Attachment content is INCLUDED in the size measurement.
+//    The body parameter is the concatenated prompt the per-bot handler will
+//    see — qwen-bot.ts and discord-bot.ts already prepend
+//    [ATTACHMENT: …] blocks. We confirm here that a human prompt that's
+//    safely tiny on its own becomes oversized once an attachment is folded
+//    in, and that triggers the human-reject branch — i.e. attachments do
+//    NOT bypass the cap.
+// -----------------------------------------------------------------------
+sect("7. attachments included in size measurement");
+{
+  const tinyText = "please summarise the attached file";
+  check(
+    "tiny prompt alone is under budget",
+    estimateTokens(tinyText) < TURN_BUDGET,
+  );
+
+  const huge = bodyOfTokens(30_000);
+  const attachmentBlock = `[ATTACHMENT: dump.txt]\n${huge}\n[/ATTACHMENT]`;
+  const fullBody = `${attachmentBlock}\n\n${tinyText}`;
+
+  const d = evaluateTurnSize(fullBody, false);
+  check(
+    "human + huge attachment → reject_human (attachment counts)",
+    d.kind === "reject_human",
+  );
+}
+
+// -----------------------------------------------------------------------
+console.log(`\n======\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -232,6 +232,84 @@ export function evaluateTurnSize(
   };
 }
 
+/**
+ * Split leading `[ATTACHMENT: name]\n…\n[/ATTACHMENT]` blocks back out of a
+ * (possibly truncated) prompt body. Used by the oversize-turn policy when a
+ * bot message gets truncated: the prepend step folds attachments into the
+ * body for size measurement, but the per-bot handler expects (content,
+ * attachments) as a split tuple. Without this split, ClaudeCode's directive
+ * detection (see discord-bot.ts:claudeHandler — `reset:` / `catch up:` /
+ * etc.) would run against a string starting with `[ATTACHMENT: …]` markup
+ * and silently never match in the truncation path.
+ *
+ * Robustness:
+ * - Closing-tag boundary: only accept `\n[/ATTACHMENT]` followed by `\n\n`
+ *   (the prepend separator before the next block / `[truncated]` marker /
+ *   subsequent prose) or end-of-string. Attachment content can legitimately
+ *   contain `\n[/ATTACHMENT]` (e.g. a markdown file documenting this very
+ *   framing); embedded false-positive closes are skipped and the search
+ *   continues for a real boundary-flanked one.
+ * - Truncate-mid-attachment: when no boundary-flanked close exists, the cut
+ *   landed inside the attachment. We push a partial attachment with as much
+ *   content as we have. If the trailing TURN_TRUNCATE_MARKER got smuggled
+ *   into that partial content (it's appended to the whole body, so when the
+ *   cut is mid-attachment the marker ends up after the partial content),
+ *   strip it back out and keep it as trailing prose so it doesn't pollute
+ *   attachment.content.
+ *
+ * Exported for direct testing — see scripts/test-oversize-turn.ts.
+ */
+export function splitLeadingAttachmentBlocks(
+  body: string,
+): { content: string; attachments: ReadAttachment[] } {
+  let remaining = body;
+  const parsed: ReadAttachment[] = [];
+  while (remaining.startsWith("[ATTACHMENT: ")) {
+    const headerEnd = remaining.indexOf("]\n");
+    if (headerEnd === -1) break;
+    const name = remaining.slice("[ATTACHMENT: ".length, headerEnd);
+    const contentStart = headerEnd + 2;
+    const closingTag = "\n[/ATTACHMENT]";
+    let closeIndex = -1;
+    let searchFrom = contentStart;
+    while (true) {
+      const candidate = remaining.indexOf(closingTag, searchFrom);
+      if (candidate === -1) break;
+      const after = candidate + closingTag.length;
+      if (after === remaining.length || remaining.startsWith("\n\n", after)) {
+        closeIndex = candidate;
+        break;
+      }
+      // Embedded close that doesn't sit at a boundary — keep looking.
+      searchFrom = candidate + 1;
+    }
+    if (closeIndex === -1) {
+      // Truncation cut mid-attachment. Build the partial content from the
+      // header onward, then peel off the appended TURN_TRUNCATE_MARKER if
+      // it got rolled into the partial — leaving the marker inside an
+      // attachment body would mislead any downstream code that treats
+      // attachment.content as verbatim file content.
+      let partial = remaining.slice(contentStart);
+      let trailing = "";
+      if (partial.endsWith(TURN_TRUNCATE_MARKER)) {
+        partial = partial.slice(0, partial.length - TURN_TRUNCATE_MARKER.length);
+        trailing = TURN_TRUNCATE_MARKER.replace(/^\n+/, "");
+      }
+      parsed.push({ name, content: partial.trimEnd() });
+      remaining = trailing;
+      break;
+    }
+    parsed.push({
+      name,
+      content: remaining.slice(contentStart, closeIndex),
+    });
+    remaining = remaining.slice(closeIndex + closingTag.length);
+    if (remaining.startsWith("\n\n")) remaining = remaining.slice(2);
+    else if (remaining.startsWith("\n")) remaining = remaining.slice(1);
+  }
+  return { content: remaining.trimStart(), attachments: parsed };
+}
+
 // --- Outbound sentinel parser ---
 //
 // Claude Code CLI emits pure prose — it has no middleware-owned tool to
@@ -1094,7 +1172,15 @@ export class BotInstance {
         `Please chunk the message into smaller pieces, or attach the content as a file ` +
         `(${allowedExtList}).`;
       try {
-        await (channel as TextChannel).send(reply);
+        // allowedMentions: { parse: [] } neutralises any user/role/everyone
+        // pings that might be smuggled in via interpolation. tokens/limit
+        // here are integers and the ext list is a constant, so the current
+        // payload is safe — but we apply the defensive form for parity with
+        // the bot-truncate warning below, where authorName IS user-controlled.
+        await (channel as TextChannel).send({
+          content: reply,
+          allowedMentions: { parse: [] },
+        });
       } catch (err) {
         console.warn(
           `[${this.displayName}] oversized-turn reject reply failed: ${err}`,
@@ -1110,7 +1196,15 @@ export class BotInstance {
     const warning =
       `⚠ ${authorName} message truncated from ${decision.originalTokens} to ${decision.truncatedTokens} tokens`;
     try {
-      await (channel as TextChannel).send(warning);
+      // authorName is user-controlled (Discord username); a name containing
+      // "@everyone" / "@here" / `<@id>` / `<@&id>` would mass-mention or
+      // ping someone unintentionally. allowedMentions: { parse: [] }
+      // neutralises every mention type so this warning never pings anyone
+      // regardless of what the originating bot's name happens to be.
+      await (channel as TextChannel).send({
+        content: warning,
+        allowedMentions: { parse: [] },
+      });
     } catch (err) {
       console.warn(
         `[${this.displayName}] oversized-turn warning failed: ${err}`,
@@ -1299,60 +1393,8 @@ export class BotInstance {
     // truncated the combined body. Without this, ClaudeCode's directive
     // detection (`reset:` / `catch up:` etc., see discord-bot.ts:claudeHandler)
     // would run against a string starting with `[ATTACHMENT: ...]` markup
-    // and silently never match. Splitting the leading attachment blocks
-    // back out keeps the directive contract intact in the truncation path.
-    const splitLeadingAttachmentBlocks = (
-      body: string,
-    ): { content: string; attachments: typeof attachments } => {
-      let remaining = body;
-      const parsed: typeof attachments = [];
-      while (remaining.startsWith("[ATTACHMENT: ")) {
-        const headerEnd = remaining.indexOf("]\n");
-        if (headerEnd === -1) break;
-        const name = remaining.slice("[ATTACHMENT: ".length, headerEnd);
-        const contentStart = headerEnd + 2;
-        const closingTag = "\n[/ATTACHMENT]";
-        // Find a closing tag that's followed by an expected boundary —
-        // either `\n\n` (the prepend separator before the next attachment,
-        // the `[truncated]` marker, or any subsequent prose) or
-        // end-of-string. Attachment content can legitimately contain
-        // `\n[/ATTACHMENT]` (e.g. a markdown file documenting this
-        // framing); without the boundary check we'd mis-split there.
-        let closeIndex = -1;
-        let searchFrom = contentStart;
-        while (true) {
-          const candidate = remaining.indexOf(closingTag, searchFrom);
-          if (candidate === -1) break;
-          const after = candidate + closingTag.length;
-          if (after === remaining.length || remaining.startsWith("\n\n", after)) {
-            closeIndex = candidate;
-            break;
-          }
-          // Embedded close — keep looking.
-          searchFrom = candidate + 1;
-        }
-        if (closeIndex === -1) {
-          // Truncation cut mid-attachment: keep the partial content and
-          // stop. The handler still gets a usable (if clipped) attachment
-          // record instead of an unparsed sentinel block in `content`.
-          parsed.push({
-            name,
-            content: remaining.slice(contentStart).trimEnd(),
-          } as (typeof attachments)[number]);
-          remaining = "";
-          break;
-        }
-        parsed.push({
-          name,
-          content: remaining.slice(contentStart, closeIndex),
-        } as (typeof attachments)[number]);
-        remaining = remaining.slice(closeIndex + closingTag.length);
-        if (remaining.startsWith("\n\n")) remaining = remaining.slice(2);
-        else if (remaining.startsWith("\n")) remaining = remaining.slice(1);
-      }
-      return { content: remaining.trimStart(), attachments: parsed };
-    };
-
+    // and silently never match. The helper is module-level so smoke tests
+    // can exercise it directly — see splitLeadingAttachmentBlocks above.
     let handlerContent = content;
     let handlerAttachments = attachments;
     if (policy.body !== composedBody) {

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -150,9 +150,14 @@ const OUTBOUND_MAX_FILES_CAP = 5;
 // clip the body so vLLM doesn't 400). The asymmetry mirrors how
 // `parseThinkingCommand` only honours human authors.
 //
-// 22_000 from ADR-0003 (slice #3 introduces the named constant in
-// qwen-harness.ts). Replace this local copy by importing from qwen-harness
-// once #3 merges.
+// 22_000 from ADR-0003 (= WIRE_HARD_CAP − SYSTEM_BUDGET). src/qwen-harness.ts
+// re-derives and exports the same value under the same name. Dedupe is
+// intentionally deferred: the right fix is to lift WIRE_HARD_CAP /
+// SYSTEM_BUDGET / TURN_BUDGET into a shared constants module rather than
+// have the Discord routing layer import from a Qwen-specific module (that
+// would couple bot-instance.ts to Qwen's harness in the wrong direction).
+// Both sides agree on the value today; if ADR-0003's split changes, the
+// follow-up extraction is the place to keep them in sync.
 export const TURN_BUDGET = 22_000;
 
 /** When a bot author goes over budget, truncate to this fraction of TURN_BUDGET. */
@@ -1344,6 +1349,11 @@ export class BotInstance {
     if (priorChunks.length > 0) {
       content = priorChunks.join("\n\n") + "\n\n" + content;
       console.log(`[${this.displayName}] stitched ${priorChunks.length} prior chunks from ${message.author.username}`);
+      // Re-trim after stitching: priorChunks[0] can carry leading whitespace
+      // that survives the join. Without this, the oversize-turn measurement
+      // (which trims composedBody) would diverge from what the handler
+      // actually receives, letting whitespace tokens slip past the cap.
+      content = content.trim();
     }
 
     if (!content) {
@@ -1384,7 +1394,12 @@ export class BotInstance {
             .map((a) => `[ATTACHMENT: ${a.name}]\n${a.content}\n[/ATTACHMENT]`)
             .join("\n\n") + "\n\n"
         : "";
-    const composedBody = (attachmentBlock + content).trim();
+    // No `.trim()` here: `content` was already trimmed (after mention-strip
+    // and again after priorChunks stitching), and `attachmentBlock` either
+    // ends with `\n\n` or is empty, so the composition has no leading or
+    // trailing whitespace. Trimming again would re-introduce the
+    // measurement / handler-input mismatch this trim discipline avoids.
+    const composedBody = attachmentBlock + content;
     const policy = await this.applyOversizeTurnPolicy(
       message.channel as TextBasedChannel,
       composedBody,

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -1350,9 +1350,9 @@ export class BotInstance {
       content = priorChunks.join("\n\n") + "\n\n" + content;
       console.log(`[${this.displayName}] stitched ${priorChunks.length} prior chunks from ${message.author.username}`);
       // Re-trim after stitching: priorChunks[0] can carry leading whitespace
-      // that survives the join. Without this, the oversize-turn measurement
-      // (which trims composedBody) would diverge from what the handler
-      // actually receives, letting whitespace tokens slip past the cap.
+      // that survives the join. Keep the stitched content normalized here so
+      // size checks and the handler see the same post-stitch text, preventing
+      // leading/trailing whitespace from slipping past the cap.
       content = content.trim();
     }
 

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -203,7 +203,8 @@ export function evaluateTurnSize(
   // Bot author: clip the body to ~90% of TURN_BUDGET in token space.
   // estimateTokens isn't reversible, but cl100k_base on ASCII prose is
   // ~3.5 chars/token, so we approximate via char ratio and verify with a
-  // re-encode. We binary-search down if the first cut still overshoots.
+  // re-encode. If the first cut still overshoots, we iteratively scale the
+  // char budget down by 10% and re-check.
   const targetTokens = Math.floor(TURN_BUDGET * TURN_TRUNCATE_FRACTION);
   // First-cut char budget: scale down by the token ratio.
   let charBudget = Math.floor((body.length * targetTokens) / Math.max(tokens, 1));
@@ -1077,10 +1078,16 @@ export class BotInstance {
     }
 
     if (decision.kind === "reject_human") {
+      // Derive the suggested-extensions list from ALLOWED_ATTACHMENT_EXTS so
+      // the user-facing reply can't drift from what readAttachments actually
+      // accepts when the allowlist evolves.
+      const allowedExtList = Array.from(ALLOWED_ATTACHMENT_EXTS)
+        .sort((a, b) => a.localeCompare(b))
+        .join("/");
       const reply =
         `Your message is ~${decision.tokens} tokens, over the per-turn cap of ${decision.limit}. ` +
         `Please chunk the message into smaller pieces, or attach the content as a file ` +
-        `(.md/.txt/.json/.yaml/.yml/.log/.csv).`;
+        `(${allowedExtList}).`;
       try {
         await (channel as TextChannel).send(reply);
       } catch (err) {
@@ -1282,15 +1289,58 @@ export class BotInstance {
       return;
     }
 
-    // Hand off to the per-bot handler. If we truncated the body, the
-    // truncated string already contains the (now-clipped) attachment
-    // blocks inline — pass an empty attachments array so the handler
-    // doesn't re-prepend the originals on top.
+    // Hand off to the per-bot handler while preserving the existing
+    // (content, attachments) split — even when the oversize policy
+    // truncated the combined body. Without this, ClaudeCode's directive
+    // detection (`reset:` / `catch up:` etc., see discord-bot.ts:claudeHandler)
+    // would run against a string starting with `[ATTACHMENT: ...]` markup
+    // and silently never match. Splitting the leading attachment blocks
+    // back out keeps the directive contract intact in the truncation path.
+    const splitLeadingAttachmentBlocks = (
+      body: string,
+    ): { content: string; attachments: typeof attachments } => {
+      let remaining = body;
+      const parsed: typeof attachments = [];
+      while (remaining.startsWith("[ATTACHMENT: ")) {
+        const headerEnd = remaining.indexOf("]\n");
+        if (headerEnd === -1) break;
+        const name = remaining.slice("[ATTACHMENT: ".length, headerEnd);
+        const contentStart = headerEnd + 2;
+        const closingTag = "\n[/ATTACHMENT]";
+        const closeIndex = remaining.indexOf(closingTag, contentStart);
+        if (closeIndex === -1) {
+          // Truncation cut mid-attachment: keep the partial content and
+          // stop. The handler still gets a usable (if clipped) attachment
+          // record instead of an unparsed sentinel block in `content`.
+          parsed.push({
+            name,
+            content: remaining.slice(contentStart).trimEnd(),
+          } as (typeof attachments)[number]);
+          remaining = "";
+          break;
+        }
+        parsed.push({
+          name,
+          content: remaining.slice(contentStart, closeIndex),
+        } as (typeof attachments)[number]);
+        remaining = remaining.slice(closeIndex + closingTag.length);
+        if (remaining.startsWith("\n\n")) remaining = remaining.slice(2);
+        else if (remaining.startsWith("\n")) remaining = remaining.slice(1);
+      }
+      return { content: remaining.trimStart(), attachments: parsed };
+    };
+
     let handlerContent = content;
     let handlerAttachments = attachments;
     if (policy.body !== composedBody) {
-      handlerContent = policy.body;
-      handlerAttachments = [];
+      if (attachments.length > 0) {
+        const split = splitLeadingAttachmentBlocks(policy.body);
+        handlerContent = split.content;
+        handlerAttachments = split.attachments;
+      } else {
+        handlerContent = policy.body;
+        handlerAttachments = [];
+      }
     }
 
     try {

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -250,12 +250,18 @@ export function evaluateTurnSize(
  *   framing); embedded false-positive closes are skipped and the search
  *   continues for a real boundary-flanked one.
  * - Truncate-mid-attachment: when no boundary-flanked close exists, the cut
- *   landed inside the attachment. We push a partial attachment with as much
- *   content as we have. If the trailing TURN_TRUNCATE_MARKER got smuggled
- *   into that partial content (it's appended to the whole body, so when the
- *   cut is mid-attachment the marker ends up after the partial content),
- *   strip it back out and keep it as trailing prose so it doesn't pollute
- *   attachment.content.
+ *   landed inside the attachment. We do NOT synthesise a parsed entry for
+ *   the partial — downstream renderers re-emit parsed attachments with a
+ *   `[/ATTACHMENT]` closing tag that was NOT in the truncated body, which
+ *   would push the handler-visible prompt past the cap evaluateTurnSize
+ *   already enforced. Instead the partial-attachment tail flows through as
+ *   plain `content` (cleanly-closed earlier attachments stay in `parsed`
+ *   because their original closing tags survived in the truncated body).
+ * - Byte-preservation: only the explicit `\n` / `\n\n` separators we know
+ *   were prepended get stripped. We never trim attachment content or the
+ *   final trailing prose — readAttachments preserves attachment content
+ *   verbatim, and downstream token estimation / directive parsing depends
+ *   on those bytes being unchanged.
  *
  * Exported for direct testing — see scripts/test-oversize-turn.ts.
  */
@@ -284,30 +290,31 @@ export function splitLeadingAttachmentBlocks(
       searchFrom = candidate + 1;
     }
     if (closeIndex === -1) {
-      // Truncation cut mid-attachment. Build the partial content from the
-      // header onward, then peel off the appended TURN_TRUNCATE_MARKER if
-      // it got rolled into the partial — leaving the marker inside an
-      // attachment body would mislead any downstream code that treats
-      // attachment.content as verbatim file content.
-      let partial = remaining.slice(contentStart);
-      let trailing = "";
-      if (partial.endsWith(TURN_TRUNCATE_MARKER)) {
-        partial = partial.slice(0, partial.length - TURN_TRUNCATE_MARKER.length);
-        trailing = TURN_TRUNCATE_MARKER.replace(/^\n+/, "");
-      }
-      parsed.push({ name, content: partial.trimEnd() });
-      remaining = trailing;
-      break;
+      // Truncation cut mid-attachment. Treat the rest as unsplittable: emit
+      // `remaining` (the partial `[ATTACHMENT: name]\n<partial-content>`
+      // tail, including any trailing `[truncated]` marker) as content. We
+      // deliberately don't synthesise a parsed entry — handlers re-render
+      // parsed attachments with a `[/ATTACHMENT]` closing tag that the
+      // budgeted body never contained, which would silently push the
+      // handler-visible prompt past evaluateTurnSize's targetTokens cap.
+      // Previously-closed attachments stay in `parsed` (their original
+      // closing tags survived intact in the truncated body, so re-emitting
+      // them doesn't add synthetic bytes).
+      return { content: remaining, attachments: parsed };
     }
     parsed.push({
       name,
       content: remaining.slice(contentStart, closeIndex),
     });
     remaining = remaining.slice(closeIndex + closingTag.length);
+    // Only strip the specific `\n` / `\n\n` separator we know was prepended
+    // to chain blocks together. Don't trim — readAttachments preserves
+    // content verbatim, so trailing prose may legitimately start with
+    // whitespace and downstream code is entitled to see it unchanged.
     if (remaining.startsWith("\n\n")) remaining = remaining.slice(2);
     else if (remaining.startsWith("\n")) remaining = remaining.slice(1);
   }
-  return { content: remaining.trimStart(), attachments: parsed };
+  return { content: remaining, attachments: parsed };
 }
 
 // --- Outbound sentinel parser ---

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -203,27 +203,32 @@ export function evaluateTurnSize(
   // Bot author: clip the body to ~90% of TURN_BUDGET in token space.
   // estimateTokens isn't reversible, but cl100k_base on ASCII prose is
   // ~3.5 chars/token, so we approximate via char ratio and verify with a
-  // re-encode. If the first cut still overshoots, we iteratively scale the
-  // char budget down by 10% and re-check.
+  // re-encode. If the first cut still overshoots (including the trailing
+  // [truncated] marker we'll append), we iteratively scale the char budget
+  // down by 10% and re-check the FULL body — accounting for the marker
+  // inside the loop guarantees the returned `truncatedTokens` actually
+  // satisfies the targetTokens invariant rather than overshooting by the
+  // marker's token cost.
   const targetTokens = Math.floor(TURN_BUDGET * TURN_TRUNCATE_FRACTION);
   // First-cut char budget: scale down by the token ratio.
   let charBudget = Math.floor((body.length * targetTokens) / Math.max(tokens, 1));
   let truncated = body.slice(0, charBudget);
-  let truncatedTokens = estimateTokens(truncated);
-  // Walk down if still over (defensive — cl100k_base can run hot on dense
-  // structured content).
+  let truncatedBody = truncated + TURN_TRUNCATE_MARKER;
+  let truncatedTokens = estimateTokens(truncatedBody);
+  // Walk down if the FINAL emitted body (content + marker) is still over
+  // budget. cl100k_base can run hot on dense structured content.
   let safety = 16;
   while (truncatedTokens > targetTokens && safety-- > 0 && charBudget > 100) {
     charBudget = Math.floor(charBudget * 0.9);
     truncated = body.slice(0, charBudget);
-    truncatedTokens = estimateTokens(truncated);
+    truncatedBody = truncated + TURN_TRUNCATE_MARKER;
+    truncatedTokens = estimateTokens(truncatedBody);
   }
-  const truncatedBody = truncated + TURN_TRUNCATE_MARKER;
   return {
     kind: "truncate_bot",
     originalTokens: tokens,
     truncatedBody,
-    truncatedTokens: estimateTokens(truncatedBody),
+    truncatedTokens,
   };
 }
 
@@ -1307,7 +1312,25 @@ export class BotInstance {
         const name = remaining.slice("[ATTACHMENT: ".length, headerEnd);
         const contentStart = headerEnd + 2;
         const closingTag = "\n[/ATTACHMENT]";
-        const closeIndex = remaining.indexOf(closingTag, contentStart);
+        // Find a closing tag that's followed by an expected boundary —
+        // either `\n\n` (the prepend separator before the next attachment,
+        // the `[truncated]` marker, or any subsequent prose) or
+        // end-of-string. Attachment content can legitimately contain
+        // `\n[/ATTACHMENT]` (e.g. a markdown file documenting this
+        // framing); without the boundary check we'd mis-split there.
+        let closeIndex = -1;
+        let searchFrom = contentStart;
+        while (true) {
+          const candidate = remaining.indexOf(closingTag, searchFrom);
+          if (candidate === -1) break;
+          const after = candidate + closingTag.length;
+          if (after === remaining.length || remaining.startsWith("\n\n", after)) {
+            closeIndex = candidate;
+            break;
+          }
+          // Embedded close — keep looking.
+          searchFrom = candidate + 1;
+        }
         if (closeIndex === -1) {
           // Truncation cut mid-attachment: keep the partial content and
           // stop. The handler still gets a usable (if clipped) attachment

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -8,6 +8,8 @@ import {
   type TextBasedChannel,
 } from "discord.js";
 
+import { estimateTokens } from "./token-estimate.js";
+
 // --- Types ---
 
 export interface TriggerRef {
@@ -139,6 +141,90 @@ const OUTBOUND_MESSAGE_BYTE_CAP = 10_000_000;
 
 /** Max files in a single outbound message (harness contract; Discord allows up to 10). */
 const OUTBOUND_MAX_FILES_CAP = 5;
+
+// --- Oversized turn handling at the Discord routing layer ---
+//
+// Per-turn token budget enforced BEFORE the per-bot handler runs. Messages
+// over budget are either rejected (human author — ask them to chunk or attach)
+// or truncated-with-warning (bot author — keep the conversation flowing but
+// clip the body so vLLM doesn't 400). The asymmetry mirrors how
+// `parseThinkingCommand` only honours human authors.
+//
+// 22_000 from ADR-0003 (slice #3 introduces the named constant in
+// qwen-harness.ts). Replace this local copy by importing from qwen-harness
+// once #3 merges.
+export const TURN_BUDGET = 22_000;
+
+/** When a bot author goes over budget, truncate to this fraction of TURN_BUDGET. */
+const TURN_TRUNCATE_FRACTION = 0.9;
+
+/** Trailing marker we append to truncated bodies before handing them to the handler. */
+const TURN_TRUNCATE_MARKER = "\n\n[truncated]";
+
+/**
+ * Decision returned by the pure size-evaluator. Exposed for testing — the
+ * routing layer's wiring method consumes the same enum.
+ */
+export type TurnSizeDecision =
+  | { kind: "ok" }
+  | { kind: "reject_human"; tokens: number; limit: number }
+  | {
+      kind: "truncate_bot";
+      originalTokens: number;
+      truncatedBody: string;
+      truncatedTokens: number;
+    };
+
+/**
+ * Pure decision function: given the (already-prepended) prompt body and
+ * whether the originating Discord author is a bot, decide what to do.
+ *
+ * Rules (issue #5):
+ *   - tokens ≤ TURN_BUDGET  →  `{ kind: "ok" }`
+ *   - human + over          →  reject (handler aborts, channel reply tells
+ *                              the user to chunk or attach the content)
+ *   - bot + over            →  truncate to ~90% of TURN_BUDGET, append a
+ *                              `[truncated]` marker, continue
+ *
+ * Token measurement uses the same `estimateTokens` helper as the rest of
+ * the harness so the cap stays consistent with downstream pre-flight checks.
+ */
+export function evaluateTurnSize(
+  body: string,
+  isBot: boolean,
+): TurnSizeDecision {
+  const tokens = estimateTokens(body);
+  if (tokens <= TURN_BUDGET) return { kind: "ok" };
+
+  if (!isBot) {
+    return { kind: "reject_human", tokens, limit: TURN_BUDGET };
+  }
+
+  // Bot author: clip the body to ~90% of TURN_BUDGET in token space.
+  // estimateTokens isn't reversible, but cl100k_base on ASCII prose is
+  // ~3.5 chars/token, so we approximate via char ratio and verify with a
+  // re-encode. We binary-search down if the first cut still overshoots.
+  const targetTokens = Math.floor(TURN_BUDGET * TURN_TRUNCATE_FRACTION);
+  // First-cut char budget: scale down by the token ratio.
+  let charBudget = Math.floor((body.length * targetTokens) / Math.max(tokens, 1));
+  let truncated = body.slice(0, charBudget);
+  let truncatedTokens = estimateTokens(truncated);
+  // Walk down if still over (defensive — cl100k_base can run hot on dense
+  // structured content).
+  let safety = 16;
+  while (truncatedTokens > targetTokens && safety-- > 0 && charBudget > 100) {
+    charBudget = Math.floor(charBudget * 0.9);
+    truncated = body.slice(0, charBudget);
+    truncatedTokens = estimateTokens(truncated);
+  }
+  const truncatedBody = truncated + TURN_TRUNCATE_MARKER;
+  return {
+    kind: "truncate_bot",
+    originalTokens: tokens,
+    truncatedBody,
+    truncatedTokens: estimateTokens(truncatedBody),
+  };
+}
 
 // --- Outbound sentinel parser ---
 //
@@ -950,6 +1036,80 @@ export class BotInstance {
     }
   }
 
+  /**
+   * Apply the issue-#5 oversized-turn policy to an inbound prompt body.
+   *
+   * Side effects on the channel:
+   *   - human + over → posts a one-line reply naming the limit and asking
+   *     for chunking or a file attachment; returns `{ abort: true }` so the
+   *     caller skips the per-bot handler.
+   *   - bot + over → posts a one-line warning identifying the originating
+   *     bot and the truncation length; returns `{ abort: false, body }` with
+   *     the truncated body (plus `[truncated]` marker) for the handler.
+   *   - under budget → no send; returns `{ abort: false, body }` unchanged.
+   *
+   * The body parameter is the FULL prompt the per-bot handler will see,
+   * including any prepended `[ATTACHMENT: …]` blocks. Attachments must NOT
+   * bypass the cap, so callers fold them in BEFORE calling this.
+   *
+   * Public so the smoke script can exercise the wiring side-effects against
+   * a stub channel without booting Discord.
+   */
+  async applyOversizeTurnPolicy(
+    channel: TextBasedChannel,
+    body: string,
+    isBot: boolean,
+    authorName: string,
+  ): Promise<{ abort: boolean; body: string }> {
+    const decision = evaluateTurnSize(body, isBot);
+    if (decision.kind === "ok") {
+      return { abort: false, body };
+    }
+
+    if (!("send" in channel)) {
+      // No way to surface the warning; degrade by aborting on human, passing
+      // through truncated body on bot. Logging keeps the operator informed.
+      console.warn(
+        `[${this.displayName}] oversized-turn policy: channel has no send(); decision=${decision.kind}`,
+      );
+      if (decision.kind === "reject_human") return { abort: true, body };
+      return { abort: false, body: decision.truncatedBody };
+    }
+
+    if (decision.kind === "reject_human") {
+      const reply =
+        `Your message is ~${decision.tokens} tokens, over the per-turn cap of ${decision.limit}. ` +
+        `Please chunk the message into smaller pieces, or attach the content as a file ` +
+        `(.md/.txt/.json/.yaml/.yml/.log/.csv).`;
+      try {
+        await (channel as TextChannel).send(reply);
+      } catch (err) {
+        console.warn(
+          `[${this.displayName}] oversized-turn reject reply failed: ${err}`,
+        );
+      }
+      console.log(
+        `[${this.displayName}] OVERSIZE-REJECT: ${authorName} sent ${decision.tokens} tokens (cap ${decision.limit})`,
+      );
+      return { abort: true, body };
+    }
+
+    // Bot + over: truncate, warn, continue.
+    const warning =
+      `⚠ ${authorName} message truncated from ${decision.originalTokens} to ${decision.truncatedTokens} tokens`;
+    try {
+      await (channel as TextChannel).send(warning);
+    } catch (err) {
+      console.warn(
+        `[${this.displayName}] oversized-turn warning failed: ${err}`,
+      );
+    }
+    console.log(
+      `[${this.displayName}] OVERSIZE-TRUNCATE: ${authorName} ${decision.originalTokens}→${decision.truncatedTokens} tokens`,
+    );
+    return { abort: false, body: decision.truncatedBody };
+  }
+
   // --- Core message dispatch ---
 
   private async handleMessage(message: Message): Promise<void> {
@@ -1100,8 +1260,41 @@ export class BotInstance {
       console.error(`[${this.displayName}] readAttachments failed: ${err}`);
     }
 
+    // --- Issue #5: oversized-turn policy at the Discord routing layer ---
+    // Compose the prompt the per-bot handler will see (mention-stripped
+    // content + any prepended [ATTACHMENT: ...] blocks) and run it through
+    // the size policy BEFORE invoking the handler. Attachments must NOT
+    // bypass the cap, so they go into the measurement here.
+    const attachmentBlock =
+      attachments.length > 0
+        ? attachments
+            .map((a) => `[ATTACHMENT: ${a.name}]\n${a.content}\n[/ATTACHMENT]`)
+            .join("\n\n") + "\n\n"
+        : "";
+    const composedBody = (attachmentBlock + content).trim();
+    const policy = await this.applyOversizeTurnPolicy(
+      message.channel as TextBasedChannel,
+      composedBody,
+      message.author.bot,
+      message.author.username,
+    );
+    if (policy.abort) {
+      return;
+    }
+
+    // Hand off to the per-bot handler. If we truncated the body, the
+    // truncated string already contains the (now-clipped) attachment
+    // blocks inline — pass an empty attachments array so the handler
+    // doesn't re-prepend the originals on top.
+    let handlerContent = content;
+    let handlerAttachments = attachments;
+    if (policy.body !== composedBody) {
+      handlerContent = policy.body;
+      handlerAttachments = [];
+    }
+
     try {
-      await this.handler(this, message, content, trigger, attachments);
+      await this.handler(this, message, handlerContent, trigger, handlerAttachments);
     } catch (err) {
       console.error(`[${this.displayName}] handler error: ${err}`);
     }


### PR DESCRIPTION
Closes #5

## Summary

Adds a pre-handler size check at the Discord routing layer (`src/bot-instance.ts`). Every inbound message in a watched channel is measured with `estimateTokens` against `TURN_BUDGET = 22_000`. Attachments are folded into the measurement so they cannot bypass the cap.

- **Human + over** → reply in-channel ("~N tokens, over the per-turn cap of 22000; please chunk or attach as a file"), abort the per-bot handler.
- **Bot + over** → truncate the body to ~90% of TURN_BUDGET, append `[truncated]`, post a one-line warning (`⚠ <Bot> message truncated from <N> to <M> tokens`), then re-split leading attachment blocks back out of the truncated body and call the handler with `(content, attachments)` preserved. The re-split is necessary so ClaudeCode's directive detection (`reset:` / `catch up:` / etc., see `src/discord-bot.ts:claudeHandler`) keeps running against un-prepended content; passing the composed body through verbatim would silently break those directives. When the cut lands mid-attachment (no boundary-flanked closing tag), the partial-attachment tail flows through as content rather than being synthesised into a parsed entry — handlers re-render parsed attachments with a `[/ATTACHMENT]` closing tag that wasn't in the budgeted body, which would push the handler-visible prompt past the cap `evaluateTurnSize` already enforced.
- **Under budget** → no-op pass-through.

The policy lives on the routing layer so `qwen-bot.ts` and `discord-bot.ts` don't need to opt in.

`TURN_BUDGET` is hardcoded in `src/bot-instance.ts` with a comment pointing at the same-named export from `src/qwen-harness.ts` (slice #3, now merged). Dedupe (centralising into a shared constants module) is deferred so this PR stays scoped to oversize-turn handling — flagged in the merge commit.

## AC → test mapping

All assertions live in `scripts/test-oversize-turn.ts` (`npm run smoketest:oversize-turn`). 56 assertions, all green.

| AC | Test |
| --- | --- |
| Pre-handler size measurement on every message | Sections 4, 5, 6 — `applyOversizeTurnPolicy` invoked in `handleMessage` after attachment download, before `this.handler(...)` |
| Attachment content included in measurement | Section 7 — tiny prompt + huge `[ATTACHMENT: …]` block triggers `reject_human` |
| Human + over → in-channel reply, handler aborted | Section 4 — asserts reply mentions the limit, suggests chunk/attach, handler spy never fires |
| Bot + over → truncate to TURN_BUDGET*0.9, `[truncated]` marker, warning posted, handler still runs | Section 5 — asserts truncated body ≤ `floor(TURN_BUDGET * 0.9)` exactly (the scaling loop measures content + marker each iteration), body has marker, warning names bot + both token counts, abort=false |
| Truncation preserves directive detection | Sections 8, 11, 11b — `splitLeadingAttachmentBlocks` re-derives `(content, attachments)` from truncated body; cleanly-closed earlier attachments recover with closing tags intact, mid-attachment cut keeps the partial-attachment tail as content (no synthetic `[/ATTACHMENT]` injection) |
| Uses `estimateTokens` helper | Imports from `src/token-estimate.ts` directly; no parallel implementation |
| Uniform across both Discord bots | Implemented on `BotInstance` itself; both `qwen-bot.ts` and `discord-bot.ts` construct one |
| Smoke script exists | `scripts/test-oversize-turn.ts` |
| `package.json` script | `smoketest:oversize-turn` added |

## Test plan

- [x] `npm run smoketest:oversize-turn` — 56/56 pass (post-merge with main)
- [x] `npm run smoketest:sentinel` — pre-existing pass (regression check on `bot-instance.ts`)
- [x] `npm run smoketest:truncation` — pre-existing pass (regression check on `sendOrAttach`)
- [x] `npx tsc --noEmit` — clean (also clean post-merge with main)

## Out of scope

- The hard wire cap and pre-flight validation themselves — slice #3 (now merged).
- Attachment ingestion improvements.
- Configurable per-channel limits.
- Resending truncated bot output as an attachment (truncate-with-warning is the chosen strategy per the brief).
- Centralising `TURN_BUDGET` into a shared constants module — deferred follow-up; flagged in the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)