### PR TITLE
Slice 2: channel transcript foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "smoketest:remember": "tsx scripts/test-remember.ts",
     "smoketest:sentinel": "tsx scripts/test-sentinel-parser.ts",
     "smoketest:truncation": "tsx scripts/test-truncation.ts",
-    "smoketest:qwen-tools": "tsx scripts/qwen-tool-smoketest.ts"
+    "smoketest:qwen-tools": "tsx scripts/qwen-tool-smoketest.ts",
+    "smoketest:channel-transcript": "tsx scripts/test-channel-transcript.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/test-channel-transcript.ts
+++ b/scripts/test-channel-transcript.ts
@@ -1,0 +1,493 @@
+// Smoke tests for src/channel-transcript.ts (Slice 2 — channel transcript foundation).
+// Run: npx tsx scripts/test-channel-transcript.ts
+//
+// The module under test exposes three async functions hiding the wing/room
+// conventions, eviction policy, and MemPalace failure handling:
+//   - writeTurn(channelId, author, text, timestamp): Promise<void>
+//   - readVerbatimWindow(channelId, excludeAuthor, k): Promise<TranscriptEntry[]>
+//   - searchProse(query, channelId?, limit): Promise<TranscriptEntry[]>
+//
+// We don't talk to a real MemPalace server here — the module exposes a
+// `_setBackendForTesting` hook (mirroring the test-state pattern PR #9
+// introduced for qwen-persona) that lets us substitute an in-memory backend.
+// The default backend wraps mempalace-client.ts; the in-memory backend is
+// only ever installed by this test script.
+
+import {
+  writeTurn,
+  readVerbatimWindow,
+  searchProse,
+  transcribeIncoming,
+  transcribeOutgoing,
+  CHANNEL_TRANSCRIPT_CAP,
+  CHANNEL_TRANSCRIPT_WING,
+  _setBackendForTesting,
+  _resetBackendForTesting,
+  _resetSeenIncomingForTesting,
+  type TranscriptBackend,
+  type TranscriptEntry,
+} from "../src/channel-transcript.js";
+
+let failed = 0;
+let passed = 0;
+
+function check(label: string, cond: boolean, detail?: string) {
+  if (cond) {
+    console.log(`  PASS  ${label}`);
+    passed++;
+  } else {
+    console.log(`  FAIL  ${label}${detail ? " — " + detail : ""}`);
+    failed++;
+  }
+}
+
+function sect(name: string) {
+  console.log(`\n--- ${name} ---`);
+}
+
+// ---------------------------------------------------------------------------
+// In-memory test backend. Mirrors the surface of the MemPalace client just
+// closely enough that the module under test can't tell the difference.
+// ---------------------------------------------------------------------------
+
+interface StoredDrawer {
+  id: string;
+  wing: string;
+  room: string;
+  content: string;
+  created_at: string;
+}
+
+function makeBackend(): TranscriptBackend & {
+  drawers: StoredDrawer[];
+  searchSpy: { query: string; wing?: string; room?: string; limit?: number }[];
+} {
+  const drawers: StoredDrawer[] = [];
+  const searchSpy: { query: string; wing?: string; room?: string; limit?: number }[] = [];
+  let counter = 0;
+  return {
+    drawers,
+    searchSpy,
+    async addDrawer(wing, room, content) {
+      counter++;
+      const id = `mock-${counter}`;
+      drawers.push({
+        id,
+        wing,
+        room,
+        content,
+        created_at: new Date().toISOString(),
+      });
+      return { success: true, drawer_id: id };
+    },
+    async listDrawers(opts) {
+      // Filter by wing/room when provided, return in insertion order.
+      let filtered = drawers.slice();
+      if (opts?.wing) filtered = filtered.filter((d) => d.wing === opts.wing);
+      if (opts?.room) filtered = filtered.filter((d) => d.room === opts.room);
+      const limit = opts?.limit ?? filtered.length;
+      const offset = opts?.offset ?? 0;
+      return filtered.slice(offset, offset + limit).map((d) => ({
+        id: d.id,
+        text: d.content,
+        wing: d.wing,
+        room: d.room,
+        created_at: d.created_at,
+      }));
+    },
+    async deleteDrawer(id) {
+      const idx = drawers.findIndex((d) => d.id === id);
+      if (idx === -1) return false;
+      drawers.splice(idx, 1);
+      return true;
+    },
+    async search(query, opts) {
+      searchSpy.push({
+        query,
+        wing: opts?.wing,
+        room: opts?.room,
+        limit: opts?.limit,
+      });
+      // Naive substring match for relevance assertions.
+      let filtered = drawers.slice();
+      if (opts?.wing) filtered = filtered.filter((d) => d.wing === opts.wing);
+      if (opts?.room) filtered = filtered.filter((d) => d.room === opts.room);
+      const matches = filtered.filter((d) =>
+        d.content.toLowerCase().includes(query.toLowerCase()),
+      );
+      const limit = opts?.limit ?? matches.length;
+      return matches.slice(0, limit).map((d) => ({
+        text: d.content,
+        wing: d.wing,
+        room: d.room,
+        similarity: 1.0,
+        distance: 0,
+        created_at: d.created_at,
+      }));
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const channel = "1234567890";
+  const otherChannel = "9876543210";
+
+  // Tests 1–6, 8 require MEMPALACE_ENABLED=true so the no-op path doesn't
+  // short-circuit the backend. Test 7 explicitly flips it to "false".
+  process.env.MEMPALACE_ENABLED = "true";
+
+  // 1. writeTurn writes one drawer with wing="conversation" and room=channelId.
+  sect("1. writeTurn — basic write");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    await writeTurn(channel, "Alice", "Hello world", "2026-04-30T12:00:00Z");
+    check("exactly one drawer was written", backend.drawers.length === 1);
+    check(
+      "wing is 'conversation'",
+      backend.drawers[0]?.wing === CHANNEL_TRANSCRIPT_WING,
+    );
+    check("room equals channelId", backend.drawers[0]?.room === channel);
+    const content = backend.drawers[0]?.content ?? "";
+    check("content carries author", content.includes("Alice"));
+    check(
+      "content carries timestamp",
+      content.includes("2026-04-30T12:00:00Z"),
+    );
+    check("content carries text", content.includes("Hello world"));
+    _resetBackendForTesting();
+  }
+
+  // 2. 500-cap eviction: 600 writes leave exactly 500 drawers, oldest evicted.
+  sect("2. eviction — 600 writes leave exactly 500 drawers");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    for (let i = 0; i < 600; i++) {
+      await writeTurn(
+        channel,
+        "Author" + i,
+        "msg " + i,
+        new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+      );
+    }
+    const transcriptDrawers = backend.drawers.filter(
+      (d) => d.wing === CHANNEL_TRANSCRIPT_WING && d.room === channel,
+    );
+    check(
+      `exactly ${CHANNEL_TRANSCRIPT_CAP} transcript drawers remain`,
+      transcriptDrawers.length === CHANNEL_TRANSCRIPT_CAP,
+      `actual=${transcriptDrawers.length}`,
+    );
+    // The first 100 messages must have been evicted; the newest 500 remain.
+    const first = transcriptDrawers[0]?.content ?? "";
+    const last =
+      transcriptDrawers[transcriptDrawers.length - 1]?.content ?? "";
+    check("oldest remaining drawer is msg 100", first.includes("msg 100"));
+    check("newest remaining drawer is msg 599", last.includes("msg 599"));
+    _resetBackendForTesting();
+  }
+
+  // 3. Layer B fact rooms are NOT subject to the cap.
+  sect("3. eviction — Layer B fact rooms unaffected");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    // Pre-populate Layer B drawers (different wings/rooms — these belong to
+    // qwen-internal facts, not the conversation transcript). They MUST survive.
+    const factRooms = [
+      "decision",
+      "naming",
+      "user_preference",
+      "canon_observation",
+    ];
+    for (const room of factRooms) {
+      for (let i = 0; i < 3; i++) {
+        backend.drawers.push({
+          id: `fact-${room}-${i}`,
+          wing: "qwen",
+          room,
+          content: `[fact] ${room} ${i}`,
+          created_at: new Date().toISOString(),
+        });
+      }
+    }
+    const factDrawerIds = new Set(
+      backend.drawers
+        .filter((d) => d.wing === "qwen")
+        .map((d) => d.id),
+    );
+    // Now write 500 transcript drawers up to the cap.
+    for (let i = 0; i < 500; i++) {
+      await writeTurn(
+        channel,
+        "Author",
+        "transcript " + i,
+        new Date(Date.UTC(2026, 0, 1, 1, 0, i)).toISOString(),
+      );
+    }
+    // ...and one more, which should evict the OLDEST transcript only.
+    await writeTurn(
+      channel,
+      "Author",
+      "transcript 500",
+      new Date(Date.UTC(2026, 0, 1, 1, 30, 0)).toISOString(),
+    );
+    const remainingFacts = backend.drawers.filter((d) =>
+      factDrawerIds.has(d.id),
+    );
+    const remainingTranscripts = backend.drawers.filter(
+      (d) => d.wing === CHANNEL_TRANSCRIPT_WING && d.room === channel,
+    );
+    check(
+      `all ${factRooms.length * 3} Layer B fact drawers preserved`,
+      remainingFacts.length === factRooms.length * 3,
+      `actual=${remainingFacts.length}`,
+    );
+    check(
+      `exactly ${CHANNEL_TRANSCRIPT_CAP} transcript drawers remain`,
+      remainingTranscripts.length === CHANNEL_TRANSCRIPT_CAP,
+      `actual=${remainingTranscripts.length}`,
+    );
+    _resetBackendForTesting();
+  }
+
+  // 4. Per-channel scope: writes to channel A do not evict channel B.
+  sect("4. eviction — per-channel scope");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    // 100 messages in channel B
+    for (let i = 0; i < 100; i++) {
+      await writeTurn(
+        otherChannel,
+        "B",
+        "B msg " + i,
+        new Date(Date.UTC(2026, 0, 2, 0, 0, i)).toISOString(),
+      );
+    }
+    // 600 messages in channel A → only A is capped
+    for (let i = 0; i < 600; i++) {
+      await writeTurn(
+        channel,
+        "A",
+        "A msg " + i,
+        new Date(Date.UTC(2026, 0, 3, 0, 0, i)).toISOString(),
+      );
+    }
+    const aCount = backend.drawers.filter(
+      (d) => d.wing === CHANNEL_TRANSCRIPT_WING && d.room === channel,
+    ).length;
+    const bCount = backend.drawers.filter(
+      (d) => d.wing === CHANNEL_TRANSCRIPT_WING && d.room === otherChannel,
+    ).length;
+    check(`channel A capped at ${CHANNEL_TRANSCRIPT_CAP}`, aCount === CHANNEL_TRANSCRIPT_CAP);
+    check("channel B untouched (100 drawers)", bCount === 100);
+    _resetBackendForTesting();
+  }
+
+  // 5. readVerbatimWindow returns most-recent K, oldest-to-newest, excluding author.
+  sect("5. readVerbatimWindow — ordering + exclusion");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    // Alternate authors so exclusion is observable.
+    const authors = ["Alice", "Bob", "Alice", "Carol", "Bob", "Alice", "Carol"];
+    for (let i = 0; i < authors.length; i++) {
+      await writeTurn(
+        channel,
+        authors[i]!,
+        `m${i}`,
+        new Date(Date.UTC(2026, 1, 1, 0, 0, i)).toISOString(),
+      );
+    }
+    // Read most recent 3 excluding Alice.
+    const window = await readVerbatimWindow(channel, "Alice", 3);
+    check("returned 3 entries", window.length === 3);
+    // Non-Alice messages in chronological order: m1 (Bob), m3 (Carol),
+    // m4 (Bob), m6 (Carol). Most-recent 3 of those are m3, m4, m6.
+    check(
+      "no Alice entries",
+      window.every((e: TranscriptEntry) => e.author !== "Alice"),
+    );
+    check(
+      "ordered oldest-to-newest by timestamp",
+      window.every(
+        (e, i) =>
+          i === 0 ||
+          new Date(e.timestamp).getTime() >=
+            new Date(window[i - 1]!.timestamp).getTime(),
+      ),
+    );
+    check("first entry is oldest of newest-3 non-Alice (m3)", window[0]?.text === "m3");
+    check("middle entry is m4", window[1]?.text === "m4");
+    check("last entry is newest non-Alice (m6)", window[2]?.text === "m6");
+    _resetBackendForTesting();
+  }
+
+  // 6. searchProse passes wing="conversation" and channel scope to the backend.
+  sect("6. searchProse — wing scope + optional channel");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    await writeTurn(channel, "Alice", "the quick brown fox", "2026-03-01T00:00:00Z");
+    await writeTurn(channel, "Bob", "lazy dog jumps", "2026-03-01T00:01:00Z");
+    await writeTurn(otherChannel, "Carol", "quick rabbit", "2026-03-01T00:02:00Z");
+
+    // Without channel scope: search the whole conversation wing.
+    const all = await searchProse("quick", undefined, 5);
+    const lastSearch = backend.searchSpy[backend.searchSpy.length - 1]!;
+    check("search wing is 'conversation'", lastSearch.wing === CHANNEL_TRANSCRIPT_WING);
+    check("search room undefined when channelId omitted", lastSearch.room === undefined);
+    check("returned 2 'quick' matches across both channels", all.length === 2);
+
+    // With channel scope: only this channel's matches.
+    const scoped = await searchProse("quick", channel, 5);
+    const scopedSearch = backend.searchSpy[backend.searchSpy.length - 1]!;
+    check("search room equals channelId when provided", scopedSearch.room === channel);
+    check("returned 1 'quick' match scoped to channel", scoped.length === 1);
+    check("scoped result is from correct channel", scoped[0]?.channelId === channel);
+    _resetBackendForTesting();
+  }
+
+  // 7. MEMPALACE_ENABLED=false → all calls are no-ops.
+  sect("7. flag-gated — no-op when MEMPALACE_ENABLED=false");
+  {
+    process.env.MEMPALACE_ENABLED = "false";
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    await writeTurn(channel, "X", "should not write", "2026-05-01T00:00:00Z");
+    check("writeTurn did not call backend", backend.drawers.length === 0);
+    const w = await readVerbatimWindow(channel, "Y", 5);
+    check("readVerbatimWindow returns []", Array.isArray(w) && w.length === 0);
+    const s = await searchProse("anything");
+    check("searchProse returns []", Array.isArray(s) && s.length === 0);
+    check("searchProse did not call backend.search", backend.searchSpy.length === 0);
+    _resetBackendForTesting();
+    // Restore for subsequent tests.
+    process.env.MEMPALACE_ENABLED = "true";
+  }
+
+  // 8. Backend errors are swallowed — writeTurn never throws.
+  sect("8. failure handling — backend errors swallowed");
+  {
+    _setBackendForTesting({
+      async addDrawer() {
+        throw new Error("backend exploded");
+      },
+      async listDrawers() {
+        throw new Error("backend exploded");
+      },
+      async deleteDrawer() {
+        return false;
+      },
+      async search() {
+        throw new Error("backend exploded");
+      },
+    });
+    let writeThrew = false;
+    try {
+      await writeTurn(channel, "A", "t", "2026-05-01T00:00:00Z");
+    } catch {
+      writeThrew = true;
+    }
+    check("writeTurn does not throw on backend failure", !writeThrew);
+
+    let readThrew = false;
+    let readVal: TranscriptEntry[] = [{ author: "x", text: "x", timestamp: "x", channelId: "x" }];
+    try {
+      readVal = await readVerbatimWindow(channel, "Y", 5);
+    } catch {
+      readThrew = true;
+    }
+    check("readVerbatimWindow does not throw", !readThrew);
+    check("readVerbatimWindow returns [] on failure", readVal.length === 0);
+
+    let searchThrew = false;
+    let searchVal: TranscriptEntry[] = [{ author: "x", text: "x", timestamp: "x", channelId: "x" }];
+    try {
+      searchVal = await searchProse("q", channel, 5);
+    } catch {
+      searchThrew = true;
+    }
+    check("searchProse does not throw", !searchThrew);
+    check("searchProse returns [] on failure", searchVal.length === 0);
+    _resetBackendForTesting();
+  }
+
+  // 9. transcribeIncoming dedupes on messageId across multiple BotInstances.
+  sect("9. transcribeIncoming — dedupe on messageId");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    _resetSeenIncomingForTesting();
+    // Two BotInstances in one process both call this for the same Discord
+    // MessageCreate event — only one drawer must be written.
+    await transcribeIncoming(
+      channel,
+      "msg-id-1",
+      "User",
+      "Hello there",
+      "2026-06-01T00:00:00Z",
+    );
+    await transcribeIncoming(
+      channel,
+      "msg-id-1",
+      "User",
+      "Hello there",
+      "2026-06-01T00:00:00Z",
+    );
+    await transcribeIncoming(
+      channel,
+      "msg-id-2",
+      "User",
+      "Another",
+      "2026-06-01T00:01:00Z",
+    );
+    check(
+      "exactly 2 drawers from 3 calls (one duplicate)",
+      backend.drawers.length === 2,
+      `actual=${backend.drawers.length}`,
+    );
+    _resetBackendForTesting();
+    _resetSeenIncomingForTesting();
+  }
+
+  // 10. transcribeOutgoing writes one drawer per call (no dedupe; bot layer
+  // controls when to send and is the sole caller per outbound message).
+  sect("10. transcribeOutgoing — one drawer per call");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    await transcribeOutgoing(
+      channel,
+      "ClaudeCode",
+      "Done.",
+      "2026-06-02T00:00:00Z",
+    );
+    await transcribeOutgoing(
+      channel,
+      "ClaudeCode",
+      "Standing by.",
+      "2026-06-02T00:00:30Z",
+    );
+    check("two drawers written", backend.drawers.length === 2);
+    check(
+      "both drawers carry the bot author",
+      backend.drawers.every((d) => d.content.includes("ClaudeCode")),
+    );
+    _resetBackendForTesting();
+  }
+
+  console.log(`\n======\n${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("FAIL:", err);
+  process.exit(1);
+});

--- a/scripts/test-channel-transcript.ts
+++ b/scripts/test-channel-transcript.ts
@@ -95,6 +95,17 @@ function makeBackend(): TranscriptBackend & {
         created_at: d.created_at,
       }));
     },
+    async getDrawer(id) {
+      const d = drawers.find((x) => x.id === id);
+      if (!d) return null;
+      return {
+        id: d.id,
+        text: d.content,
+        wing: d.wing,
+        room: d.room,
+        created_at: d.created_at,
+      };
+    },
     async deleteDrawer(id) {
       const idx = drawers.findIndex((d) => d.id === id);
       if (idx === -1) return false;
@@ -382,6 +393,9 @@ async function main() {
       async listDrawers() {
         throw new Error("backend exploded");
       },
+      async getDrawer() {
+        throw new Error("backend exploded");
+      },
       async deleteDrawer() {
         return false;
       },
@@ -479,6 +493,195 @@ async function main() {
     check(
       "both drawers carry the bot author",
       backend.drawers.every((d) => d.content.includes("ClaudeCode")),
+    );
+    _resetBackendForTesting();
+  }
+
+  // 11. Per-channel mutex: concurrent writeTurns to one channel must not
+  // overlap their add+enforceCap critical sections, even when each call's
+  // backend ops slow-pipe through `await`. Without serialisation the two
+  // calls would interleave list+delete and the cap would drift.
+  sect("11. mutex — concurrent writes to one channel are serialised");
+  {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const recorded: string[] = [];
+    const slowBackend: TranscriptBackend = {
+      async addDrawer(_w, _r, content) {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        recorded.push(`add:${content.match(/"text":"([^"]+)"/)?.[1] ?? "?"}`);
+        await new Promise((res) => setTimeout(res, 5));
+        inFlight--;
+        return { success: true, drawer_id: `id-${recorded.length}` };
+      },
+      async listDrawers() {
+        recorded.push("list");
+        return [];
+      },
+      async getDrawer() {
+        return null;
+      },
+      async deleteDrawer() {
+        return true;
+      },
+      async search() {
+        return [];
+      },
+    };
+    _setBackendForTesting(slowBackend);
+    await Promise.all([
+      writeTurn(channel, "A", "first", "2026-07-01T00:00:00Z"),
+      writeTurn(channel, "A", "second", "2026-07-01T00:00:01Z"),
+      writeTurn(channel, "A", "third", "2026-07-01T00:00:02Z"),
+    ]);
+    check(
+      "no two writeTurns held the backend concurrently",
+      maxInFlight === 1,
+      `maxInFlight=${maxInFlight}`,
+    );
+    check(
+      "writes hit the backend in submission order",
+      recorded.filter((s) => s.startsWith("add:")).join("|") ===
+        "add:first|add:second|add:third",
+      `recorded=${recorded.join(",")}`,
+    );
+    _resetBackendForTesting();
+  }
+
+  // 12. Preview truncation (Comment #2): when listDrawers' content_preview
+  // is shorter than the full envelope, peekEnvelopeTs must still recover ts
+  // from the prefix so enforceCap evicts the right drawers.
+  sect("12. enforceCap — sorts correctly under preview truncation");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    // Manually populate CAP + 5 drawers, descending ts (so insertion order
+    // is opposite of age order — the sort is doing real work). Each
+    // drawer's content is the full envelope but artificially truncated to
+    // 60 chars to simulate a server-side preview cap.
+    const fullEnvelopes: { content: string; truncated: string; ts: string }[] = [];
+    for (let i = 0; i < CHANNEL_TRANSCRIPT_CAP + 5; i++) {
+      const ts = new Date(
+        Date.UTC(2026, 0, 1, 0, 0, CHANNEL_TRANSCRIPT_CAP + 5 - i),
+      ).toISOString();
+      const fullText = "x".repeat(200);
+      const env = JSON.stringify({ v: 1, ts, author: "A", text: fullText });
+      const truncated = env.slice(0, 60);
+      fullEnvelopes.push({ content: env, truncated, ts });
+      backend.drawers.push({
+        id: `pre-${i}`,
+        wing: CHANNEL_TRANSCRIPT_WING,
+        room: channel,
+        content: truncated,
+        created_at: new Date().toISOString(),
+      });
+    }
+    // Trigger eviction via one more writeTurn.
+    await writeTurn(
+      channel,
+      "A",
+      "trigger",
+      "2026-01-02T00:00:00.000Z",
+    );
+    const transcriptDrawers = backend.drawers.filter(
+      (d) => d.wing === CHANNEL_TRANSCRIPT_WING && d.room === channel,
+    );
+    check(
+      `converges to CAP after one write under preview truncation`,
+      transcriptDrawers.length === CHANNEL_TRANSCRIPT_CAP,
+      `actual=${transcriptDrawers.length}`,
+    );
+    // Oldest 5 (highest indices in fullEnvelopes — those had the smallest
+    // ts because we built ts in reverse) plus the new "trigger" drawer
+    // should determine survivors.
+    const survivedIds = new Set(transcriptDrawers.map((d) => d.id));
+    check(
+      "the trigger drawer survives",
+      survivedIds.size > 0 &&
+        backend.drawers.some(
+          (d) => d.content.includes('"text":"trigger"') && survivedIds.has(d.id),
+        ),
+    );
+    _resetBackendForTesting();
+  }
+
+  // 13. Backlog convergence (Comment #3): if the channel starts above
+  // CAP + 1, one writeTurn should catch us up — not drift one drawer per
+  // write.
+  sect("13. enforceCap — converges from a >CAP+1 backlog in one write");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    // Pre-populate 600 valid envelope drawers (CAP + 100).
+    for (let i = 0; i < CHANNEL_TRANSCRIPT_CAP + 100; i++) {
+      const ts = new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString();
+      backend.drawers.push({
+        id: `back-${i}`,
+        wing: CHANNEL_TRANSCRIPT_WING,
+        room: channel,
+        content: JSON.stringify({ v: 1, ts, author: "A", text: "msg " + i }),
+        created_at: ts,
+      });
+    }
+    await writeTurn(
+      channel,
+      "A",
+      "trigger",
+      "2026-01-02T00:00:00.000Z",
+    );
+    const remaining = backend.drawers.filter(
+      (d) => d.wing === CHANNEL_TRANSCRIPT_WING && d.room === channel,
+    );
+    check(
+      `single write converges 600+1 → ${CHANNEL_TRANSCRIPT_CAP}`,
+      remaining.length === CHANNEL_TRANSCRIPT_CAP,
+      `actual=${remaining.length}`,
+    );
+    _resetBackendForTesting();
+  }
+
+  // 14. NaN-safe sort (Comment #4): a drawer with a malformed ts must not
+  // poison the sort or cause the read path to throw.
+  sect("14. malformed ts — sort is NaN-safe and reads still work");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    backend.drawers.push({
+      id: "bad-ts-1",
+      wing: CHANNEL_TRANSCRIPT_WING,
+      room: channel,
+      content: JSON.stringify({
+        v: 1,
+        ts: "not-a-real-date",
+        author: "A",
+        text: "garbage ts",
+      }),
+      created_at: new Date().toISOString(),
+    });
+    backend.drawers.push({
+      id: "good-ts-1",
+      wing: CHANNEL_TRANSCRIPT_WING,
+      room: channel,
+      content: JSON.stringify({
+        v: 1,
+        ts: "2026-08-01T00:00:00.000Z",
+        author: "A",
+        text: "valid ts",
+      }),
+      created_at: new Date().toISOString(),
+    });
+    let threw = false;
+    let entries: TranscriptEntry[] = [];
+    try {
+      entries = await readVerbatimWindow(channel, "Z", 5);
+    } catch {
+      threw = true;
+    }
+    check("readVerbatimWindow does not throw on malformed ts", !threw);
+    check(
+      "valid-ts entry surfaces in the window",
+      entries.some((e) => e.text === "valid ts"),
     );
     _resetBackendForTesting();
   }

--- a/scripts/test-channel-transcript.ts
+++ b/scripts/test-channel-transcript.ts
@@ -18,7 +18,6 @@ import {
   readVerbatimWindow,
   searchProse,
   transcribeIncoming,
-  transcribeOutgoing,
   CHANNEL_TRANSCRIPT_CAP,
   CHANNEL_TRANSCRIPT_WING,
   _setBackendForTesting,
@@ -471,30 +470,38 @@ async function main() {
     _resetSeenIncomingForTesting();
   }
 
-  // 10. transcribeOutgoing writes one drawer per call (no dedupe; bot layer
-  // controls when to send and is the sole caller per outbound message).
-  sect("10. transcribeOutgoing — one drawer per call");
+  // 10. Outgoing-via-incoming dedupe: when the bot's own send and a sibling
+  // BotInstance both transcribe the same Discord message id, only one
+  // drawer is written. This is the architectural fix for duplicate
+  // outbound captures (formerly transcribeOutgoing wrote unconditionally).
+  sect("10. transcribeIncoming — outbound + sibling dedupe on shared id");
   {
     const backend = makeBackend();
     _setBackendForTesting(backend);
-    await transcribeOutgoing(
+    _resetSeenIncomingForTesting();
+    // Bot A's own captureOutgoing fires first.
+    await transcribeIncoming(
       channel,
+      "shared-msg-id",
       "ClaudeCode",
       "Done.",
       "2026-06-02T00:00:00Z",
     );
-    await transcribeOutgoing(
+    // Sibling Bot B's handleMessage observes the same MessageCreate.
+    await transcribeIncoming(
       channel,
+      "shared-msg-id",
       "ClaudeCode",
-      "Standing by.",
-      "2026-06-02T00:00:30Z",
+      "Done.",
+      "2026-06-02T00:00:00Z",
     );
-    check("two drawers written", backend.drawers.length === 2);
     check(
-      "both drawers carry the bot author",
-      backend.drawers.every((d) => d.content.includes("ClaudeCode")),
+      "exactly 1 drawer from 2 calls on the same Discord message id",
+      backend.drawers.length === 1,
+      `actual=${backend.drawers.length}`,
     );
     _resetBackendForTesting();
+    _resetSeenIncomingForTesting();
   }
 
   // 11. Per-channel mutex: concurrent writeTurns to one channel must not
@@ -684,6 +691,192 @@ async function main() {
       entries.some((e) => e.text === "valid ts"),
     );
     _resetBackendForTesting();
+  }
+
+  // 15. JSON-safe author extraction (Comment B): an author name containing
+  // an embedded quote (Discord allows display names with special chars
+  // through nicknames) must be recovered correctly when the preview is
+  // not truncated. Regex-only path would split on the inner quote.
+  sect("15. readVerbatimWindow — JSON-safe author with embedded quote");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    backend.drawers.push({
+      id: "quoted-author",
+      wing: CHANNEL_TRANSCRIPT_WING,
+      room: channel,
+      content: JSON.stringify({
+        v: 1,
+        ts: "2026-09-01T00:00:00.000Z",
+        author: 'name with "quote" inside',
+        text: "hello",
+      }),
+      created_at: new Date().toISOString(),
+    });
+    const window = await readVerbatimWindow(channel, "ZZ", 5);
+    check(
+      "quoted-author entry surfaces with full author preserved",
+      window.some((e) => e.author === 'name with "quote" inside'),
+      `entries=${JSON.stringify(window)}`,
+    );
+    // Author exclusion using the exact JSON-decoded string also works.
+    const excluded = await readVerbatimWindow(
+      channel,
+      'name with "quote" inside',
+      5,
+    );
+    check(
+      "exclude-by-author matches against JSON-decoded author",
+      excluded.length === 0,
+    );
+    _resetBackendForTesting();
+  }
+
+  // 16. channelLocks cleanup (Comment C): after the queued work for a
+  // channel settles and no later writer chained on top, the lock entry is
+  // removed. Otherwise the Map would grow unbounded with channel turnover.
+  sect("16. channelLocks — entry removed after settle (no-tail case)");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    const ephemeralChannel = "5555000000";
+    await writeTurn(
+      ephemeralChannel,
+      "X",
+      "one and done",
+      "2026-09-02T00:00:00Z",
+    );
+    // settled.finally fires asynchronously — yield once so the cleanup
+    // microtask runs.
+    await new Promise((res) => setImmediate(res));
+    // The Map is module-private; we observe its size indirectly by
+    // checking that subsequent writes still work and that a second write
+    // to the same channel doesn't see a stale entry.
+    await writeTurn(
+      ephemeralChannel,
+      "X",
+      "two",
+      "2026-09-02T00:00:01Z",
+    );
+    await new Promise((res) => setImmediate(res));
+    check(
+      "two writes to one ephemeral channel both wrote drawers",
+      backend.drawers.filter(
+        (d) => d.wing === CHANNEL_TRANSCRIPT_WING && d.room === ephemeralChannel,
+      ).length === 2,
+    );
+    _resetBackendForTesting();
+  }
+
+  // 17. enforceCap pages until convergence (Comment D): a backlog larger
+  // than CAP*2+1 takes more than one list iteration but converges.
+  sect("17. enforceCap — pages backlog > CAP*2+1 across iterations");
+  {
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    // CAP = 500. Pre-populate 1500 (> CAP*2+1 = 1001) valid envelope drawers.
+    const TOTAL = CHANNEL_TRANSCRIPT_CAP * 3;
+    for (let i = 0; i < TOTAL; i++) {
+      const ts = new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString();
+      backend.drawers.push({
+        id: `huge-${i}`,
+        wing: CHANNEL_TRANSCRIPT_WING,
+        room: channel,
+        content: JSON.stringify({ v: 1, ts, author: "A", text: "msg " + i }),
+        created_at: ts,
+      });
+    }
+    await writeTurn(
+      channel,
+      "A",
+      "trigger",
+      "2026-01-02T00:00:00.000Z",
+    );
+    const remaining = backend.drawers.filter(
+      (d) => d.wing === CHANNEL_TRANSCRIPT_WING && d.room === channel,
+    );
+    check(
+      `paged loop converges ${TOTAL}+1 → ${CHANNEL_TRANSCRIPT_CAP}`,
+      remaining.length === CHANNEL_TRANSCRIPT_CAP,
+      `actual=${remaining.length}`,
+    );
+    _resetBackendForTesting();
+  }
+
+  // 18. enforceCap surfaces deleteDrawer-returns-false (Comment E): the
+  // default mempalace client returns false on soft delete failure without
+  // throwing. enforceCap must log those and stop spinning when no progress
+  // is being made (otherwise it loops up to MAX_ITERATIONS).
+  sect("18. enforceCap — handles deleteDrawer returning false");
+  {
+    let listCalls = 0;
+    let deleteCalls = 0;
+    const errors: string[] = [];
+    const origError = console.error;
+    const origWarn = console.warn;
+    const capture = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+    console.error = capture;
+    console.warn = capture;
+    try {
+      // Fill ≥ LIST_LIMIT (CAP*2+1 = 1001) so the "got the full set" early
+      // exit doesn't fire and we reach the no-progress check.
+      const STUCK_COUNT = CHANNEL_TRANSCRIPT_CAP * 2 + 1;
+      const stuckDrawers = Array.from({ length: STUCK_COUNT }, (_, i) => {
+        const ts = new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString();
+        return {
+          id: `stuck-${i}`,
+          text: JSON.stringify({ v: 1, ts, author: "A", text: "x" }),
+          wing: CHANNEL_TRANSCRIPT_WING,
+          room: channel,
+        };
+      });
+      _setBackendForTesting({
+        async addDrawer() {
+          return { success: true, drawer_id: "added-1" };
+        },
+        async listDrawers() {
+          listCalls++;
+          return stuckDrawers;
+        },
+        async getDrawer() {
+          return null;
+        },
+        async deleteDrawer() {
+          deleteCalls++;
+          return false;
+        },
+        async search() {
+          return [];
+        },
+      });
+      await writeTurn(channel, "A", "x", "2026-01-01T00:00:00.000Z");
+    } finally {
+      console.error = origError;
+      console.warn = origWarn;
+      _resetBackendForTesting();
+    }
+    const overflow = CHANNEL_TRANSCRIPT_CAP * 2 + 1 - CHANNEL_TRANSCRIPT_CAP;
+    check(
+      "enforceCap stopped after no-progress iteration (single list pass)",
+      listCalls === 1,
+      `listCalls=${listCalls}`,
+    );
+    check(
+      "enforceCap attempted every overflow delete in the iter",
+      deleteCalls === overflow,
+      `deleteCalls=${deleteCalls} expected=${overflow}`,
+    );
+    check(
+      "every false-return surfaced via console.error",
+      errors.filter((e) => e.includes("returned false")).length === overflow,
+      `falseErrors=${errors.filter((e) => e.includes("returned false")).length}`,
+    );
+    check(
+      "no-progress warning was logged",
+      errors.some((e) => e.includes("made no progress")),
+    );
   }
 
   console.log(`\n======\n${passed} passed, ${failed} failed`);

--- a/scripts/test-channel-transcript.ts
+++ b/scripts/test-channel-transcript.ts
@@ -879,6 +879,43 @@ async function main() {
     );
   }
 
+  // 19. transcribeIncoming respects MEMPALACE_ENABLED before mutating the
+  // dedupe LRU (Comment I). An id observed while disabled must remain
+  // eligible once MemPalace comes back online.
+  sect("19. transcribeIncoming — flag-gated before markSeen mutation");
+  {
+    process.env.MEMPALACE_ENABLED = "false";
+    _resetSeenIncomingForTesting();
+    const backend = makeBackend();
+    _setBackendForTesting(backend);
+    await transcribeIncoming(
+      channel,
+      "rotates-id",
+      "U",
+      "first observation",
+      "2026-09-03T00:00:00Z",
+    );
+    check(
+      "no drawer written while disabled",
+      backend.drawers.length === 0,
+    );
+    process.env.MEMPALACE_ENABLED = "true";
+    await transcribeIncoming(
+      channel,
+      "rotates-id",
+      "U",
+      "later observation",
+      "2026-09-03T00:00:01Z",
+    );
+    check(
+      "after re-enable, the same id was captured (LRU not mutated while disabled)",
+      backend.drawers.length === 1,
+      `actual=${backend.drawers.length}`,
+    );
+    _resetBackendForTesting();
+    _resetSeenIncomingForTesting();
+  }
+
   console.log(`\n======\n${passed} passed, ${failed} failed`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -7,6 +7,10 @@ import {
   type Message,
   type TextBasedChannel,
 } from "discord.js";
+import {
+  transcribeIncoming,
+  transcribeOutgoing,
+} from "./channel-transcript.js";
 
 // --- Types ---
 
@@ -512,6 +516,27 @@ export class BotInstance {
     return null;
   }
 
+  // --- Transcript capture helper ---
+
+  /**
+   * Fire-and-forget: record an outgoing reply in the channel transcript.
+   * Called from sendOrAttach / sendWithFiles after a successful send. The
+   * author is this BotInstance's displayName so readVerbatimWindow's
+   * exclude-by-author filter works the same way for both incoming and
+   * outgoing turns. No-op when MEMPALACE_ENABLED=false (handled inside
+   * the module).
+   */
+  private captureOutgoing(channel: TextBasedChannel, text: string): void {
+    const channelId = (channel as { id?: string }).id;
+    if (!channelId) return;
+    void transcribeOutgoing(
+      channelId,
+      this.displayName,
+      text,
+      new Date().toISOString(),
+    );
+  }
+
   // --- Discord helpers ---
 
   async safeReact(channelId: string, messageId: string, emoji: string): Promise<void> {
@@ -666,6 +691,7 @@ export class BotInstance {
 
     if (full.length <= MESSAGE_INLINE_MAX) {
       await (channel as TextChannel).send(full);
+      this.captureOutgoing(channel, text);
       return;
     }
 
@@ -732,6 +758,10 @@ export class BotInstance {
     }
 
     await (channel as TextChannel).send(out);
+    // Capture the FULL pre-truncation text — the transcript is for AGENT
+    // memory, not for what humans saw. Truncation is a Discord-display
+    // concern.
+    this.captureOutgoing(channel, text);
   }
 
   /**
@@ -806,6 +836,11 @@ export class BotInstance {
       (f) => new AttachmentBuilder(Buffer.from(f.content, "utf-8"), { name: f.name }),
     );
     await (channel as TextChannel).send({ content: inline, files: attachments });
+    // Transcript records the inline summary (the human-visible prose).
+    // Attachment file bodies are intentionally excluded; if a downstream
+    // agent needs an attachment's contents, it should re-fetch via the
+    // canon RAG / dcc layer rather than rehydrate megabytes from MemPalace.
+    this.captureOutgoing(channel, summary);
   }
 
   /**
@@ -964,6 +999,21 @@ export class BotInstance {
     if (this.allowedChannelIds && !this.allowedChannelIds.has(message.channel.id)) {
       return;
     }
+
+    // --- Channel transcript capture (slice #2) ---
+    // Persist every message we observe in a watched channel into the
+    // shared MemPalace conversation wing BEFORE the per-bot mention filter.
+    // The dedupe inside transcribeIncoming makes this idempotent across
+    // multiple BotInstances seeing the same MessageCreate event. No-op
+    // when MEMPALACE_ENABLED is not "true". Failures are swallowed inside
+    // the module; never block the bot reply path on transcript failure.
+    void transcribeIncoming(
+      message.channel.id,
+      message.id,
+      message.author.username,
+      message.content,
+      new Date(message.createdTimestamp).toISOString(),
+    );
 
     // STRICT: respond ONLY to (a) a proper user @mention, (b) a mention of one
     // of our configured mention-roles, or (c) a text-match against our

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -9,7 +9,6 @@ import {
 } from "discord.js";
 import {
   transcribeIncoming,
-  transcribeOutgoing,
 } from "./channel-transcript.js";
 
 // --- Types ---
@@ -520,20 +519,22 @@ export class BotInstance {
 
   /**
    * Fire-and-forget: record an outgoing reply in the channel transcript.
-   * Called from sendOrAttach / sendWithFiles after a successful send. The
-   * author is this BotInstance's displayName so readVerbatimWindow's
-   * exclude-by-author filter works the same way for both incoming and
-   * outgoing turns. No-op when MEMPALACE_ENABLED=false (handled inside
-   * the module).
+   * Routes through `transcribeIncoming` keyed on the sent Discord message's
+   * id so sibling BotInstances that observe the same MessageCreate event
+   * don't write a duplicate drawer. Author is taken from `sent.author`
+   * (the bot's actual Discord username) so it matches what `handleMessage`
+   * records for inbound messages — keeping `readVerbatimWindow`'s
+   * exclude-by-author filter symmetric across directions.
+   *
+   * No-op when MEMPALACE_ENABLED=false (handled inside the module).
    */
-  private captureOutgoing(channel: TextBasedChannel, text: string): void {
-    const channelId = (channel as { id?: string }).id;
-    if (!channelId) return;
-    void transcribeOutgoing(
-      channelId,
-      this.displayName,
+  private captureOutgoing(sent: Message, text: string): void {
+    void transcribeIncoming(
+      sent.channel.id,
+      sent.id,
+      sent.author.username,
       text,
-      new Date().toISOString(),
+      new Date(sent.createdTimestamp).toISOString(),
     );
   }
 
@@ -690,8 +691,8 @@ export class BotInstance {
     const full = mention ? `${mention} ${text}` : text;
 
     if (full.length <= MESSAGE_INLINE_MAX) {
-      await (channel as TextChannel).send(full);
-      this.captureOutgoing(channel, text);
+      const sent = await (channel as TextChannel).send(full);
+      this.captureOutgoing(sent, text);
       return;
     }
 
@@ -757,11 +758,11 @@ export class BotInstance {
       out = out.slice(0, MESSAGE_INLINE_MAX);
     }
 
-    await (channel as TextChannel).send(out);
+    const sent = await (channel as TextChannel).send(out);
     // Capture the FULL pre-truncation text — the transcript is for AGENT
     // memory, not for what humans saw. Truncation is a Discord-display
     // concern.
-    this.captureOutgoing(channel, text);
+    this.captureOutgoing(sent, text);
   }
 
   /**
@@ -835,12 +836,15 @@ export class BotInstance {
     const attachments: AttachmentBuilder[] = files.map(
       (f) => new AttachmentBuilder(Buffer.from(f.content, "utf-8"), { name: f.name }),
     );
-    await (channel as TextChannel).send({ content: inline, files: attachments });
+    const sent = await (channel as TextChannel).send({
+      content: inline,
+      files: attachments,
+    });
     // Transcript records the inline summary (the human-visible prose).
     // Attachment file bodies are intentionally excluded; if a downstream
     // agent needs an attachment's contents, it should re-fetch via the
     // canon RAG / dcc layer rather than rehydrate megabytes from MemPalace.
-    this.captureOutgoing(channel, summary);
+    this.captureOutgoing(sent, summary);
   }
 
   /**

--- a/src/channel-transcript.ts
+++ b/src/channel-transcript.ts
@@ -1,0 +1,429 @@
+/**
+ * channel-transcript.ts — per-channel shared transcript foundation.
+ *
+ * Captures every Discord message (incoming user/bot AND outgoing bot reply)
+ * in a watched channel as a drawer in the MemPalace `conversation` wing,
+ * room=<channelId>. This is the cross-agent shared memory layer: a decision
+ * NemoClaw made earlier in the channel becomes visible to Qwen on the next
+ * turn through `readVerbatimWindow` (slice #6) and `searchProse` (slice #7).
+ *
+ * Design notes:
+ *
+ * 1. Wing/room conventions are HIDDEN behind this module. Callers pass
+ *    channelId; they never construct wing="conversation" themselves. This is
+ *    the deep-module property the brief calls for: a small typed surface
+ *    (writeTurn, readVerbatimWindow, searchProse) over a richer policy
+ *    (eviction, format, failure handling).
+ *
+ * 2. The 500-message-per-channel cap is enforced CLIENT-SIDE. The MemPalace
+ *    HTTP API as it exists today exposes /drawer (POST), /drawer/:id (DELETE),
+ *    /drawers/list (POST), and /search (POST), with no per-(wing,room) cap
+ *    setting on the server. Adding one would require changes to the MemPalace
+ *    server outside this repo's control. Client-side cap is the right
+ *    trade-off for slice #2: transcript writes are infrequent (one per
+ *    Discord message), the list+delete cost is bounded (≤501 drawers per
+ *    channel even in the worst case), and it keeps the MemPalace contract
+ *    unchanged. ADR-0004 (activity-bounded retention) governs this choice.
+ *
+ * 3. Each drawer's content is a JSON envelope of {author, timestamp, text}.
+ *    We do this rather than relying on MemPalace metadata because the list
+ *    endpoint returns only a content_preview and the search endpoint returns
+ *    only a flat text field — embedding the metadata in content survives
+ *    both and lets readVerbatimWindow/searchProse reconstruct typed entries
+ *    without per-drawer GETs.
+ *
+ * 4. MEMPALACE_ENABLED=false makes every call a no-op (matches mempalace-
+ *    client.ts). This is checked LAZILY on each call so tests can flip the
+ *    env var between cases without re-importing the module.
+ *
+ * 5. The backend is injectable via _setBackendForTesting (mirrors the
+ *    _resetCacheForTesting pattern from src/qwen-persona.ts introduced in
+ *    PR #9). The default backend wraps mempalace-client.ts; tests substitute
+ *    an in-memory backend.
+ */
+
+import {
+  isEnabled,
+  mpAddDrawer,
+  mpListDrawers,
+  mpDeleteDrawer,
+  mpSearch,
+  type DrawerEntry,
+  type SearchResult,
+} from "./mempalace-client.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** MemPalace wing for cross-agent channel transcripts. */
+export const CHANNEL_TRANSCRIPT_WING = "conversation";
+
+/**
+ * Per-channel cap on transcript drawers. ADR-0004 (activity-bounded
+ * transcript retention): drop-oldest-on-write at 500. No byte cap; oversize
+ * messages are filtered upstream (slice #5).
+ */
+export const CHANNEL_TRANSCRIPT_CAP = 500;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A reconstructed transcript entry returned by read/search. */
+export interface TranscriptEntry {
+  channelId: string;
+  author: string;
+  text: string;
+  /** ISO 8601. */
+  timestamp: string;
+}
+
+/**
+ * Backend the module uses to talk to drawer storage. Production wires this
+ * to mempalace-client.ts; tests can install an in-memory backend.
+ */
+export interface TranscriptBackend {
+  addDrawer(
+    wing: string,
+    room: string,
+    content: string,
+  ): Promise<{ success: boolean; drawer_id?: string; error?: string }>;
+  listDrawers(opts?: {
+    wing?: string;
+    room?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<DrawerEntry[]>;
+  deleteDrawer(id: string): Promise<boolean>;
+  search(
+    query: string,
+    opts?: { wing?: string; room?: string; limit?: number },
+  ): Promise<SearchResult[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Default backend — thin wrapper over mempalace-client.
+// ---------------------------------------------------------------------------
+
+const defaultBackend: TranscriptBackend = {
+  async addDrawer(wing, room, content) {
+    const r = await mpAddDrawer(wing, room, content, { added_by: "transcript" });
+    return { success: r.success, drawer_id: r.drawer_id, error: r.error };
+  },
+  async listDrawers(opts) {
+    return mpListDrawers(opts);
+  },
+  async deleteDrawer(id) {
+    return mpDeleteDrawer(id);
+  },
+  async search(query, opts) {
+    return mpSearch(query, opts);
+  },
+};
+
+let backend: TranscriptBackend = defaultBackend;
+
+// ---------------------------------------------------------------------------
+// Test-state hooks (mirrors src/qwen-persona.ts:_resetCacheForTesting from
+// PR #9). Production code never calls these.
+// ---------------------------------------------------------------------------
+
+export function _setBackendForTesting(b: TranscriptBackend): void {
+  backend = b;
+}
+
+export function _resetBackendForTesting(): void {
+  backend = defaultBackend;
+}
+
+// ---------------------------------------------------------------------------
+// Envelope (de)serialisation. Compact JSON keeps drawer content searchable
+// while letting us recover {author, timestamp, text} losslessly.
+// ---------------------------------------------------------------------------
+
+interface Envelope {
+  v: 1;
+  author: string;
+  ts: string;
+  text: string;
+}
+
+function encodeEnvelope(author: string, timestamp: string, text: string): string {
+  const env: Envelope = { v: 1, author, ts: timestamp, text };
+  return JSON.stringify(env);
+}
+
+/**
+ * Decode a drawer-content envelope. Tolerates legacy/malformed entries by
+ * returning null — callers skip those rather than crashing the whole read.
+ */
+function decodeEnvelope(content: string): Envelope | null {
+  if (typeof content !== "string" || content.length === 0) return null;
+  try {
+    const parsed = JSON.parse(content);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.author === "string" &&
+      typeof parsed.ts === "string" &&
+      typeof parsed.text === "string"
+    ) {
+      return { v: 1, author: parsed.author, ts: parsed.ts, text: parsed.text };
+    }
+  } catch {
+    // Not JSON — fall through.
+  }
+  return null;
+}
+
+function entryFromDrawer(d: DrawerEntry): TranscriptEntry | null {
+  const env = decodeEnvelope(d.text);
+  if (!env) return null;
+  return {
+    channelId: d.room,
+    author: env.author,
+    text: env.text,
+    timestamp: env.ts,
+  };
+}
+
+function entryFromSearchResult(r: SearchResult): TranscriptEntry | null {
+  const env = decodeEnvelope(r.text);
+  if (!env) return null;
+  return {
+    channelId: r.room,
+    author: env.author,
+    text: env.text,
+    timestamp: env.ts,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Persist one Discord turn into the channel transcript wing.
+ *
+ * Writes a drawer to `wing="conversation"`, `room=channelId` whose content
+ * is a JSON envelope of {author, timestamp, text}. After the write, if the
+ * channel now holds more than CHANNEL_TRANSCRIPT_CAP transcript drawers,
+ * the oldest are deleted (drop-oldest-on-write). Failure paths (write or
+ * delete) are logged but never thrown — transcript capture must not break
+ * the bot's reply path.
+ *
+ * No-op when MEMPALACE_ENABLED is not "true".
+ */
+export async function writeTurn(
+  channelId: string,
+  author: string,
+  text: string,
+  timestamp: string,
+): Promise<void> {
+  if (!isEnabled()) return;
+  try {
+    const content = encodeEnvelope(author, timestamp, text);
+    const result = await backend.addDrawer(
+      CHANNEL_TRANSCRIPT_WING,
+      channelId,
+      content,
+    );
+    if (!result.success) {
+      console.error(
+        `[channel-transcript] addDrawer failed for room=${channelId}: ${result.error ?? "unknown"}`,
+      );
+      return;
+    }
+    await enforceCap(channelId);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[channel-transcript] writeTurn failed: ${msg}`);
+  }
+}
+
+/**
+ * Return the most recent K transcript entries for `channelId` whose author
+ * is NOT `excludeAuthor`. Result is ordered oldest-to-newest so callers can
+ * splice it directly into a chronological prompt.
+ *
+ * No-op (returns []) when MEMPALACE_ENABLED is not "true".
+ */
+export async function readVerbatimWindow(
+  channelId: string,
+  excludeAuthor: string,
+  k: number,
+): Promise<TranscriptEntry[]> {
+  if (!isEnabled()) return [];
+  if (k <= 0) return [];
+  try {
+    // Pull a generous slice (up to the cap) and filter client-side. The
+    // MemPalace list endpoint does not support author filtering today.
+    const drawers = await backend.listDrawers({
+      wing: CHANNEL_TRANSCRIPT_WING,
+      room: channelId,
+      limit: CHANNEL_TRANSCRIPT_CAP,
+    });
+    const entries = drawers
+      .map(entryFromDrawer)
+      .filter((e): e is TranscriptEntry => e !== null)
+      .filter((e) => e.author !== excludeAuthor);
+    // Sort oldest-to-newest by timestamp.
+    entries.sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+    );
+    // Take the last k (most recent).
+    return entries.slice(-k);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[channel-transcript] readVerbatimWindow failed: ${msg}`);
+    return [];
+  }
+}
+
+/**
+ * Semantic search over the conversation wing. When `channelId` is provided,
+ * the search is scoped to that channel's room; otherwise it covers every
+ * channel's transcripts in the wing. Returns at most `limit` entries
+ * (default 5).
+ *
+ * No-op (returns []) when MEMPALACE_ENABLED is not "true".
+ */
+export async function searchProse(
+  query: string,
+  channelId?: string,
+  limit = 5,
+): Promise<TranscriptEntry[]> {
+  if (!isEnabled()) return [];
+  try {
+    const opts: { wing: string; room?: string; limit: number } = {
+      wing: CHANNEL_TRANSCRIPT_WING,
+      limit,
+    };
+    if (channelId !== undefined) opts.room = channelId;
+    const results = await backend.search(query, opts);
+    return results
+      .map(entryFromSearchResult)
+      .filter((e): e is TranscriptEntry => e !== null);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[channel-transcript] searchProse failed: ${msg}`);
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bot-routing helpers — single integration point for the Discord layer.
+// The brief asks the routing layer to capture incoming AND outgoing turns
+// without per-agent code paths. These wrappers live in this module so the
+// dedupe + author conventions stay in one place.
+// ---------------------------------------------------------------------------
+
+/**
+ * In-process LRU of (messageId) keys that have already been transcribed this
+ * run. Multiple BotInstances live in one process and all receive the same
+ * Discord MessageCreate events; without this dedupe, every message would be
+ * written N times (once per BotInstance whose intents matched).
+ *
+ * Bounded so a long-running process can't grow this without limit.
+ */
+const SEEN_INCOMING_IDS_CAP = 5000;
+const seenIncomingIds = new Set<string>();
+const seenIncomingOrder: string[] = [];
+
+function markSeen(messageId: string): boolean {
+  if (seenIncomingIds.has(messageId)) return false;
+  seenIncomingIds.add(messageId);
+  seenIncomingOrder.push(messageId);
+  while (seenIncomingOrder.length > SEEN_INCOMING_IDS_CAP) {
+    const evicted = seenIncomingOrder.shift();
+    if (evicted) seenIncomingIds.delete(evicted);
+  }
+  return true;
+}
+
+export function _resetSeenIncomingForTesting(): void {
+  seenIncomingIds.clear();
+  seenIncomingOrder.length = 0;
+}
+
+/**
+ * Capture an incoming Discord message into the transcript wing. Idempotent
+ * on `messageId` — repeated calls (e.g. from multiple BotInstances handling
+ * the same MessageCreate event) are no-ops after the first.
+ *
+ * Oversize-message filtering happens upstream (slice #5) before this is
+ * called.
+ */
+export async function transcribeIncoming(
+  channelId: string,
+  messageId: string,
+  author: string,
+  text: string,
+  timestamp: string,
+): Promise<void> {
+  if (!markSeen(messageId)) return;
+  await writeTurn(channelId, author, text, timestamp);
+}
+
+/**
+ * Capture an outgoing bot reply (the bot's own utterance) into the transcript
+ * wing. No dedupe here: the bot layer calls this exactly once per send. The
+ * `author` is the bot's display name or user id — chosen to mirror the
+ * incoming author convention so readVerbatimWindow's exclude-by-author
+ * filter works symmetrically.
+ */
+export async function transcribeOutgoing(
+  channelId: string,
+  author: string,
+  text: string,
+  timestamp: string,
+): Promise<void> {
+  await writeTurn(channelId, author, text, timestamp);
+}
+
+// ---------------------------------------------------------------------------
+// Cap enforcement (client-side, post-write)
+// ---------------------------------------------------------------------------
+
+/**
+ * After a write, if the channel exceeds CHANNEL_TRANSCRIPT_CAP transcript
+ * drawers, delete the oldest until it doesn't. Layer B fact rooms (qwen
+ * wing — `decision`, `naming`, `user_preference`, `canon_observation`) are
+ * NEVER touched here: the list query is scoped to wing="conversation",
+ * room=channelId, so fact drawers are out of scope by construction.
+ */
+async function enforceCap(channelId: string): Promise<void> {
+  // Fetch one over the cap to detect the overflow condition.
+  const drawers = await backend.listDrawers({
+    wing: CHANNEL_TRANSCRIPT_WING,
+    room: channelId,
+    limit: CHANNEL_TRANSCRIPT_CAP + 1,
+  });
+  if (drawers.length <= CHANNEL_TRANSCRIPT_CAP) return;
+
+  // Order oldest-first by timestamp from the envelope (falls back to
+  // listing order for legacy/undecodable entries — those go first so they
+  // are the first evicted).
+  const annotated = drawers.map((d) => {
+    const env = decodeEnvelope(d.text);
+    const ts = env ? new Date(env.ts).getTime() : 0;
+    return { d, ts };
+  });
+  annotated.sort((a, b) => a.ts - b.ts);
+
+  const overflow = annotated.length - CHANNEL_TRANSCRIPT_CAP;
+  for (let i = 0; i < overflow; i++) {
+    const id = annotated[i]?.d.id;
+    if (!id) continue;
+    try {
+      await backend.deleteDrawer(id);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[channel-transcript] evict failed for drawer ${id}: ${msg}`,
+      );
+    }
+  }
+}

--- a/src/channel-transcript.ts
+++ b/src/channel-transcript.ts
@@ -21,9 +21,12 @@
  *    setting on the server. Adding one would require changes to the MemPalace
  *    server outside this repo's control. Client-side cap is the right
  *    trade-off for slice #2: transcript writes are infrequent (one per
- *    Discord message), the list+delete cost is bounded (≤501 drawers per
- *    channel even in the worst case), and it keeps the MemPalace contract
- *    unchanged. ADR-0004 (activity-bounded retention) governs this choice.
+ *    Discord message), and it keeps the MemPalace contract unchanged.
+ *    Cap-enforcement cost per writeTurn is bounded by `enforceCap`'s paged
+ *    loop: at most `ENFORCE_CAP_MAX_ITERATIONS` (5) list passes of up to
+ *    `CAP*2+1` (1001) drawers each, plus a delete per overflow drawer.
+ *    Steady-state (channel at-or-near cap) is one list + at most one delete.
+ *    ADR-0004 (activity-bounded retention) governs this choice.
  *
  * 3. Each drawer's content is a JSON envelope of {author, timestamp, text}.
  *    We do this rather than relying on MemPalace metadata because the list
@@ -444,26 +447,26 @@ export async function searchProse(
  * Discord MessageCreate events; without this dedupe, every message would be
  * written N times (once per BotInstance whose intents matched).
  *
- * Bounded so a long-running process can't grow this without limit.
+ * Backed by a single `Map` so `has` / `set` / oldest-eviction are all O(1)
+ * (Map iteration follows insertion order, so `keys().next().value` is the
+ * oldest entry). Bounded so a long-running process can't grow this without
+ * limit.
  */
 const SEEN_INCOMING_IDS_CAP = 5000;
-const seenIncomingIds = new Set<string>();
-const seenIncomingOrder: string[] = [];
+const seenIncoming = new Map<string, true>();
 
 function markSeen(messageId: string): boolean {
-  if (seenIncomingIds.has(messageId)) return false;
-  seenIncomingIds.add(messageId);
-  seenIncomingOrder.push(messageId);
-  while (seenIncomingOrder.length > SEEN_INCOMING_IDS_CAP) {
-    const evicted = seenIncomingOrder.shift();
-    if (evicted) seenIncomingIds.delete(evicted);
+  if (seenIncoming.has(messageId)) return false;
+  seenIncoming.set(messageId, true);
+  if (seenIncoming.size > SEEN_INCOMING_IDS_CAP) {
+    const oldest = seenIncoming.keys().next().value;
+    if (oldest !== undefined) seenIncoming.delete(oldest);
   }
   return true;
 }
 
 export function _resetSeenIncomingForTesting(): void {
-  seenIncomingIds.clear();
-  seenIncomingOrder.length = 0;
+  seenIncoming.clear();
 }
 
 /**
@@ -485,6 +488,10 @@ export async function transcribeIncoming(
   text: string,
   timestamp: string,
 ): Promise<void> {
+  // Flag check FIRST so the dedupe LRU is not mutated when the module is
+  // disabled — otherwise an id seen while disabled would be silently skipped
+  // when MemPalace later comes back online.
+  if (!isEnabled()) return;
   if (!markSeen(messageId)) return;
   await writeTurn(channelId, author, text, timestamp);
 }

--- a/src/channel-transcript.ts
+++ b/src/channel-transcript.ts
@@ -45,6 +45,7 @@
 import {
   isEnabled,
   mpAddDrawer,
+  mpGetDrawer,
   mpListDrawers,
   mpDeleteDrawer,
   mpSearch,
@@ -95,6 +96,13 @@ export interface TranscriptBackend {
     limit?: number;
     offset?: number;
   }): Promise<DrawerEntry[]>;
+  /**
+   * Fetch one drawer's *full* content by id. `listDrawers` returns
+   * `content_preview` (server-truncated) — when the envelope JSON exceeds
+   * that preview, decode fails and we lose the entry. `readVerbatimWindow`
+   * uses this to recover full content for the window it actually returns.
+   */
+  getDrawer(id: string): Promise<DrawerEntry | null>;
   deleteDrawer(id: string): Promise<boolean>;
   search(
     query: string,
@@ -113,6 +121,10 @@ const defaultBackend: TranscriptBackend = {
   },
   async listDrawers(opts) {
     return mpListDrawers(opts);
+  },
+  async getDrawer(id) {
+    const r = await mpGetDrawer(id);
+    return r.drawer ?? null;
   },
   async deleteDrawer(id) {
     return mpDeleteDrawer(id);
@@ -144,13 +156,17 @@ export function _resetBackendForTesting(): void {
 
 interface Envelope {
   v: 1;
-  author: string;
   ts: string;
+  author: string;
   text: string;
 }
 
 function encodeEnvelope(author: string, timestamp: string, text: string): string {
-  const env: Envelope = { v: 1, author, ts: timestamp, text };
+  // Key order is load-bearing: `mpListDrawers` returns a server-truncated
+  // `content_preview`. Putting `ts` and `author` ahead of the (potentially
+  // long) `text` field keeps those fields recoverable by `peekEnvelope*`
+  // even when the preview is truncated mid-`text`.
+  const env: Envelope = { v: 1, ts: timestamp, author, text };
   return JSON.stringify(env);
 }
 
@@ -169,12 +185,38 @@ function decodeEnvelope(content: string): Envelope | null {
       typeof parsed.ts === "string" &&
       typeof parsed.text === "string"
     ) {
-      return { v: 1, author: parsed.author, ts: parsed.ts, text: parsed.text };
+      return { v: 1, ts: parsed.ts, author: parsed.author, text: parsed.text };
     }
   } catch {
     // Not JSON — fall through.
   }
   return null;
+}
+
+/**
+ * Peek at a (possibly preview-truncated) envelope and recover ts as a
+ * millisecond epoch suitable for sorting. `enforceCap` and the sort step in
+ * `readVerbatimWindow` only need ts, so we tolerate truncation here rather
+ * than dropping the entry. Returns 0 (sorts oldest, evicted first) for
+ * undecodable / malformed / NaN-date entries.
+ */
+function peekEnvelopeTs(content: string): number {
+  if (typeof content !== "string" || content.length === 0) return 0;
+  try {
+    const parsed = JSON.parse(content);
+    if (parsed && typeof parsed.ts === "string") {
+      const t = new Date(parsed.ts).getTime();
+      return Number.isFinite(t) ? t : 0;
+    }
+  } catch {
+    // Truncated preview — fall through to regex fallback.
+  }
+  const m = content.match(/"ts"\s*:\s*"([^"]+)"/);
+  if (m && m[1]) {
+    const t = new Date(m[1]).getTime();
+    return Number.isFinite(t) ? t : 0;
+  }
+  return 0;
 }
 
 function entryFromDrawer(d: DrawerEntry): TranscriptEntry | null {
@@ -200,6 +242,36 @@ function entryFromSearchResult(r: SearchResult): TranscriptEntry | null {
 }
 
 // ---------------------------------------------------------------------------
+// Per-channel write serialisation. The Discord layer fires `writeTurn` calls
+// without awaiting them (`void transcribeIncoming(...)` in bot-instance.ts),
+// so two messages in the same channel can have overlapping
+// add → enforceCap → list → delete sequences. Without serialisation the cap
+// drifts above CHANNEL_TRANSCRIPT_CAP and ADR-0004's "atomic eviction"
+// contract breaks. We chain each channel's writes through a per-channel
+// promise so add+enforceCap is mutually exclusive within a process.
+// ---------------------------------------------------------------------------
+
+const channelLocks = new Map<string, Promise<void>>();
+
+function withChannelLock<T>(
+  channelId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prev = channelLocks.get(channelId) ?? Promise.resolve();
+  const result = prev.then(() => fn());
+  // Swallow rejection on the lock chain so one failed write doesn't poison
+  // every subsequent write for that channel.
+  channelLocks.set(
+    channelId,
+    result.then(
+      () => {},
+      () => {},
+    ),
+  );
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -209,9 +281,10 @@ function entryFromSearchResult(r: SearchResult): TranscriptEntry | null {
  * Writes a drawer to `wing="conversation"`, `room=channelId` whose content
  * is a JSON envelope of {author, timestamp, text}. After the write, if the
  * channel now holds more than CHANNEL_TRANSCRIPT_CAP transcript drawers,
- * the oldest are deleted (drop-oldest-on-write). Failure paths (write or
- * delete) are logged but never thrown — transcript capture must not break
- * the bot's reply path.
+ * the oldest are deleted (drop-oldest-on-write). Add and cap-enforcement
+ * are serialised per channel (see `withChannelLock`). Failure paths (write
+ * or delete) are logged but never thrown — transcript capture must not
+ * break the bot's reply path.
  *
  * No-op when MEMPALACE_ENABLED is not "true".
  */
@@ -222,24 +295,26 @@ export async function writeTurn(
   timestamp: string,
 ): Promise<void> {
   if (!isEnabled()) return;
-  try {
-    const content = encodeEnvelope(author, timestamp, text);
-    const result = await backend.addDrawer(
-      CHANNEL_TRANSCRIPT_WING,
-      channelId,
-      content,
-    );
-    if (!result.success) {
-      console.error(
-        `[channel-transcript] addDrawer failed for room=${channelId}: ${result.error ?? "unknown"}`,
+  return withChannelLock(channelId, async () => {
+    try {
+      const content = encodeEnvelope(author, timestamp, text);
+      const result = await backend.addDrawer(
+        CHANNEL_TRANSCRIPT_WING,
+        channelId,
+        content,
       );
-      return;
+      if (!result.success) {
+        console.error(
+          `[channel-transcript] addDrawer failed for room=${channelId}: ${result.error ?? "unknown"}`,
+        );
+        return;
+      }
+      await enforceCap(channelId);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[channel-transcript] writeTurn failed: ${msg}`);
     }
-    await enforceCap(channelId);
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[channel-transcript] writeTurn failed: ${msg}`);
-  }
+  });
 }
 
 /**
@@ -264,17 +339,36 @@ export async function readVerbatimWindow(
       room: channelId,
       limit: CHANNEL_TRANSCRIPT_CAP,
     });
-    const entries = drawers
-      .map(entryFromDrawer)
-      .filter((e): e is TranscriptEntry => e !== null)
-      .filter((e) => e.author !== excludeAuthor);
-    // Sort oldest-to-newest by timestamp.
-    entries.sort(
-      (a, b) =>
-        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
-    );
-    // Take the last k (most recent).
-    return entries.slice(-k);
+    // List returns content_preview, so envelope.text may be truncated and
+    // decodeEnvelope may return null. Sort by ts (peeked from the truncated
+    // preview) before slicing, then re-fetch full content for the K we
+    // actually return.
+    const annotatedAuthors = drawers
+      .map((d) => {
+        const m = d.text.match(/"author"\s*:\s*"([^"]+)"/);
+        const author = m && m[1] ? m[1] : "";
+        return { d, ts: peekEnvelopeTs(d.text), author };
+      })
+      .filter((a) => a.author !== "" && a.author !== excludeAuthor);
+    annotatedAuthors.sort((a, b) => a.ts - b.ts);
+    const candidates = annotatedAuthors.slice(-k);
+
+    // Resolve each candidate to a full TranscriptEntry. Try the preview
+    // first (cheap path — succeeds whenever the envelope fit in the
+    // preview); fall back to a single-drawer GET when JSON.parse fails.
+    const entries: TranscriptEntry[] = [];
+    for (const a of candidates) {
+      const fromPreview = entryFromDrawer(a.d);
+      if (fromPreview) {
+        entries.push(fromPreview);
+        continue;
+      }
+      const full = await backend.getDrawer(a.d.id);
+      if (!full) continue;
+      const fromFull = entryFromDrawer(full);
+      if (fromFull) entries.push(fromFull);
+    }
+    return entries;
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[channel-transcript] readVerbatimWindow failed: ${msg}`);
@@ -395,22 +489,21 @@ export async function transcribeOutgoing(
  * room=channelId, so fact drawers are out of scope by construction.
  */
 async function enforceCap(channelId: string): Promise<void> {
-  // Fetch one over the cap to detect the overflow condition.
+  // List with generous slack so any real-world backlog (existing data,
+  // delete failures from prior runs, multi-process writes pre-mutex) is
+  // catchable in one pass — the previous CAP+1 limit could only delete one
+  // drawer per write, never converging if the channel was further over.
   const drawers = await backend.listDrawers({
     wing: CHANNEL_TRANSCRIPT_WING,
     room: channelId,
-    limit: CHANNEL_TRANSCRIPT_CAP + 1,
+    limit: CHANNEL_TRANSCRIPT_CAP * 2 + 1,
   });
   if (drawers.length <= CHANNEL_TRANSCRIPT_CAP) return;
 
-  // Order oldest-first by timestamp from the envelope (falls back to
-  // listing order for legacy/undecodable entries — those go first so they
-  // are the first evicted).
-  const annotated = drawers.map((d) => {
-    const env = decodeEnvelope(d.text);
-    const ts = env ? new Date(env.ts).getTime() : 0;
-    return { d, ts };
-  });
+  // Order oldest-first by ts peeked from the (possibly preview-truncated)
+  // envelope. peekEnvelopeTs returns 0 for undecodable / NaN-date / missing
+  // ts entries — those sort first so they're the first evicted.
+  const annotated = drawers.map((d) => ({ d, ts: peekEnvelopeTs(d.text) }));
   annotated.sort((a, b) => a.ts - b.ts);
 
   const overflow = annotated.length - CHANNEL_TRANSCRIPT_CAP;

--- a/src/channel-transcript.ts
+++ b/src/channel-transcript.ts
@@ -194,29 +194,46 @@ function decodeEnvelope(content: string): Envelope | null {
 }
 
 /**
- * Peek at a (possibly preview-truncated) envelope and recover ts as a
- * millisecond epoch suitable for sorting. `enforceCap` and the sort step in
- * `readVerbatimWindow` only need ts, so we tolerate truncation here rather
- * than dropping the entry. Returns 0 (sorts oldest, evicted first) for
- * undecodable / malformed / NaN-date entries.
+ * Peek at a (possibly preview-truncated) envelope and recover ts + author
+ * without requiring full JSON parse. JSON.parse is preferred (JSON-safe for
+ * escaped quotes / backslashes in author names); the regex fallback is only
+ * used when the preview is truncated mid-JSON. ts of 0 sorts oldest /
+ * evicted first; author of "" means "unrecoverable". The regex paths are
+ * best-effort under truncation — they do not handle every escape sequence.
  */
-function peekEnvelopeTs(content: string): number {
-  if (typeof content !== "string" || content.length === 0) return 0;
+function peekEnvelope(content: string): { ts: number; author: string } {
+  if (typeof content !== "string" || content.length === 0) {
+    return { ts: 0, author: "" };
+  }
   try {
     const parsed = JSON.parse(content);
-    if (parsed && typeof parsed.ts === "string") {
-      const t = new Date(parsed.ts).getTime();
-      return Number.isFinite(t) ? t : 0;
+    if (parsed && typeof parsed === "object") {
+      let ts = 0;
+      let author = "";
+      if (typeof parsed.ts === "string") {
+        const t = new Date(parsed.ts).getTime();
+        if (Number.isFinite(t)) ts = t;
+      }
+      if (typeof parsed.author === "string") author = parsed.author;
+      return { ts, author };
     }
   } catch {
-    // Truncated preview — fall through to regex fallback.
+    // Truncated preview — fall through to regex (best-effort, JSON-unsafe).
   }
-  const m = content.match(/"ts"\s*:\s*"([^"]+)"/);
-  if (m && m[1]) {
-    const t = new Date(m[1]).getTime();
-    return Number.isFinite(t) ? t : 0;
+  let ts = 0;
+  let author = "";
+  const tsMatch = content.match(/"ts"\s*:\s*"([^"]+)"/);
+  if (tsMatch && tsMatch[1]) {
+    const t = new Date(tsMatch[1]).getTime();
+    if (Number.isFinite(t)) ts = t;
   }
-  return 0;
+  const authorMatch = content.match(/"author"\s*:\s*"([^"]+)"/);
+  if (authorMatch && authorMatch[1]) author = authorMatch[1];
+  return { ts, author };
+}
+
+function peekEnvelopeTs(content: string): number {
+  return peekEnvelope(content).ts;
 }
 
 function entryFromDrawer(d: DrawerEntry): TranscriptEntry | null {
@@ -261,13 +278,19 @@ function withChannelLock<T>(
   const result = prev.then(() => fn());
   // Swallow rejection on the lock chain so one failed write doesn't poison
   // every subsequent write for that channel.
-  channelLocks.set(
-    channelId,
-    result.then(
-      () => {},
-      () => {},
-    ),
+  const settled = result.then(
+    () => {},
+    () => {},
   );
+  channelLocks.set(channelId, settled);
+  // When this chain settles, drop the entry only if no later writer chained
+  // on top of us. Bounds the map to the active write set (rather than the
+  // lifetime channel set) for processes that see many ephemeral channelIds.
+  void settled.finally(() => {
+    if (channelLocks.get(channelId) === settled) {
+      channelLocks.delete(channelId);
+    }
+  });
   return result;
 }
 
@@ -342,12 +365,13 @@ export async function readVerbatimWindow(
     // List returns content_preview, so envelope.text may be truncated and
     // decodeEnvelope may return null. Sort by ts (peeked from the truncated
     // preview) before slicing, then re-fetch full content for the K we
-    // actually return.
+    // actually return. peekEnvelope tries JSON.parse first (JSON-safe for
+    // escaped quotes / backslashes in usernames) and falls back to a regex
+    // only on parse failure.
     const annotatedAuthors = drawers
       .map((d) => {
-        const m = d.text.match(/"author"\s*:\s*"([^"]+)"/);
-        const author = m && m[1] ? m[1] : "";
-        return { d, ts: peekEnvelopeTs(d.text), author };
+        const env = peekEnvelope(d.text);
+        return { d, ts: env.ts, author: env.author };
       })
       .filter((a) => a.author !== "" && a.author !== excludeAuthor);
     annotatedAuthors.sort((a, b) => a.ts - b.ts);
@@ -443,12 +467,16 @@ export function _resetSeenIncomingForTesting(): void {
 }
 
 /**
- * Capture an incoming Discord message into the transcript wing. Idempotent
- * on `messageId` — repeated calls (e.g. from multiple BotInstances handling
- * the same MessageCreate event) are no-ops after the first.
+ * Capture a Discord message into the transcript wing. Idempotent on
+ * `messageId`: repeated calls (e.g. from sibling BotInstances handling the
+ * same MessageCreate event, OR from the bot's own send-side capture
+ * arriving before/after siblings see the event) are no-ops after the first.
  *
- * Oversize-message filtering happens upstream (slice #5) before this is
- * called.
+ * Use the same call shape for both directions — the bot's own send must
+ * pass the sent `Message.id` and `Message.author.username` so its drawer is
+ * deduped against the sibling-bot incoming view of the same Discord
+ * message. Oversize-message filtering happens upstream (slice #5) before
+ * this is called.
  */
 export async function transcribeIncoming(
   channelId: string,
@@ -458,22 +486,6 @@ export async function transcribeIncoming(
   timestamp: string,
 ): Promise<void> {
   if (!markSeen(messageId)) return;
-  await writeTurn(channelId, author, text, timestamp);
-}
-
-/**
- * Capture an outgoing bot reply (the bot's own utterance) into the transcript
- * wing. No dedupe here: the bot layer calls this exactly once per send. The
- * `author` is the bot's display name or user id — chosen to mirror the
- * incoming author convention so readVerbatimWindow's exclude-by-author
- * filter works symmetrically.
- */
-export async function transcribeOutgoing(
-  channelId: string,
-  author: string,
-  text: string,
-  timestamp: string,
-): Promise<void> {
   await writeTurn(channelId, author, text, timestamp);
 }
 
@@ -488,35 +500,66 @@ export async function transcribeOutgoing(
  * NEVER touched here: the list query is scoped to wing="conversation",
  * room=channelId, so fact drawers are out of scope by construction.
  */
+/**
+ * Bound on the convergence loop in `enforceCap`. A pathological channel
+ * (e.g. >>CAP*2 backlog from prior delete failures or multi-process writes)
+ * is paged through across this many iterations. Beyond that, we log and
+ * return — the next writeTurn will resume convergence.
+ */
+const ENFORCE_CAP_MAX_ITERATIONS = 5;
+
 async function enforceCap(channelId: string): Promise<void> {
-  // List with generous slack so any real-world backlog (existing data,
-  // delete failures from prior runs, multi-process writes pre-mutex) is
-  // catchable in one pass — the previous CAP+1 limit could only delete one
-  // drawer per write, never converging if the channel was further over.
-  const drawers = await backend.listDrawers({
-    wing: CHANNEL_TRANSCRIPT_WING,
-    room: channelId,
-    limit: CHANNEL_TRANSCRIPT_CAP * 2 + 1,
-  });
-  if (drawers.length <= CHANNEL_TRANSCRIPT_CAP) return;
+  const LIST_LIMIT = CHANNEL_TRANSCRIPT_CAP * 2 + 1;
+  for (let iter = 0; iter < ENFORCE_CAP_MAX_ITERATIONS; iter++) {
+    const drawers = await backend.listDrawers({
+      wing: CHANNEL_TRANSCRIPT_WING,
+      room: channelId,
+      limit: LIST_LIMIT,
+    });
+    if (drawers.length <= CHANNEL_TRANSCRIPT_CAP) return;
 
-  // Order oldest-first by ts peeked from the (possibly preview-truncated)
-  // envelope. peekEnvelopeTs returns 0 for undecodable / NaN-date / missing
-  // ts entries — those sort first so they're the first evicted.
-  const annotated = drawers.map((d) => ({ d, ts: peekEnvelopeTs(d.text) }));
-  annotated.sort((a, b) => a.ts - b.ts);
+    // Order oldest-first by ts peeked from the (possibly preview-truncated)
+    // envelope. peekEnvelopeTs returns 0 for undecodable / NaN-date /
+    // missing ts entries — those sort first so they're the first evicted.
+    const annotated = drawers.map((d) => ({ d, ts: peekEnvelopeTs(d.text) }));
+    annotated.sort((a, b) => a.ts - b.ts);
 
-  const overflow = annotated.length - CHANNEL_TRANSCRIPT_CAP;
-  for (let i = 0; i < overflow; i++) {
-    const id = annotated[i]?.d.id;
-    if (!id) continue;
-    try {
-      await backend.deleteDrawer(id);
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(
-        `[channel-transcript] evict failed for drawer ${id}: ${msg}`,
+    const overflow = annotated.length - CHANNEL_TRANSCRIPT_CAP;
+    let evictedThisIter = 0;
+    for (let i = 0; i < overflow; i++) {
+      const id = annotated[i]?.d.id;
+      if (!id) continue;
+      try {
+        const ok = await backend.deleteDrawer(id);
+        if (ok) {
+          evictedThisIter++;
+        } else {
+          // Default backend (mempalace-client.ts:208) returns false on soft
+          // failure (HTTP error) without throwing — surface those.
+          console.error(
+            `[channel-transcript] deleteDrawer returned false for drawer ${id} (room=${channelId})`,
+          );
+        }
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(
+          `[channel-transcript] evict failed for drawer ${id}: ${msg}`,
+        );
+      }
+    }
+    // Two early-exit conditions: (1) we got the full set in one list (so
+    // we know nothing remains beyond what we just processed), or (2) no
+    // delete actually succeeded this iter (further iterations would loop
+    // on the same un-deletable drawers).
+    if (drawers.length < LIST_LIMIT) return;
+    if (evictedThisIter === 0) {
+      console.warn(
+        `[channel-transcript] enforceCap made no progress for room=${channelId}; channel may remain over cap`,
       );
+      return;
     }
   }
+  console.warn(
+    `[channel-transcript] enforceCap hit max iterations (${ENFORCE_CAP_MAX_ITERATIONS}) for room=${channelId}; next writeTurn will resume convergence`,
+  );
 }


### PR DESCRIPTION
## Summary

Implements [slice 2](https://github.com/dcolclazier/agent-middleware/issues/2) of the cross-agent-memory PRD — the foundation slice that #6, #7, and #8 build on.

- New `src/channel-transcript.ts` deep module exposing `writeTurn`, `readVerbatimWindow`, `searchProse`, plus a single `transcribeIncoming` helper used by the Discord-bot routing layer for both inbound user/sibling-bot messages **and** the bot's own outbound replies. All async, all flag-gated on `MEMPALACE_ENABLED`, all swallow backend failures so the bot reply path never breaks on a MemPalace blip.
- `src/bot-instance.ts` calls `transcribeIncoming` after the channel allowlist check (before the per-bot mention filter, so non-mentioning user/bot messages are still captured). Outgoing capture (`captureOutgoing`) takes the `Message` returned by `channel.send(...)` and routes through the same `transcribeIncoming(channelId, sent.id, sent.author.username, ...)` so the dedupe LRU keyed on `messageId` collapses the bot's send-side hook against any sibling BotInstance's incoming view of the same Discord message — exactly one drawer per Discord message across the process. The Claude async-reply path goes through `postToDiscord` → `sendOrAttach` / `sendWithFiles`, so it's covered by the same hook.
- The 500-per-channel cap is enforced **client-side** (post-write list-and-delete-oldest, scoped to `wing="conversation"`/`room=channelId`) via `enforceCap`'s bounded paged loop (`ENFORCE_CAP_MAX_ITERATIONS = 5`, `LIST_LIMIT = CAP*2+1 = 1001`). Steady-state cost is one list + at most one delete per `writeTurn`; pathological backlogs converge across multiple iterations. MemPalace's HTTP API has no per-(wing,room) cap setting today, and adding one would require a server change outside this repo. Layer B fact rooms (`decision`, `naming`, `user_preference`, `canon_observation` in `wing="qwen"`) are out of scope by construction, so they're never touched. Choice documented at the top of the module.
- Per-channel mutex (`withChannelLock`) chains `writeTurn` calls per channel through a promise so `add + enforceCap` is mutually exclusive, satisfying ADR-0004's "atomic eviction" contract under fire-and-forget concurrent Discord events. The lock map cleans up its entry on settle when no later writer chained, bounding it to the active write set rather than the lifetime channel set.
- Drawer content is a compact `{v, ts, author, text}` JSON envelope (key order is load-bearing — `mpListDrawers` returns a server-truncated `content_preview`, so short metadata at the prefix survives truncation). `peekEnvelope` recovers `{ts, author}` for sort/exclude even from truncated previews; `readVerbatimWindow` re-fetches full content via `mpGetDrawer` for the K entries it actually returns.
- Backend is injectable via `_setBackendForTesting` (mirrors the `_resetCacheForTesting` test-state-hook pattern PR #9 introduces in `src/qwen-persona.ts`), so the new smoke script runs entirely in-memory — no live MemPalace required.

## Acceptance criteria → tests

| AC from agent brief | Verified by |
| --- | --- |
| Module exports `writeTurn` / `readVerbatimWindow` / `searchProse` with the contracted signatures | Test 1 (writeTurn shape) + Tests 5, 6 (read/search shape); also enforced by `tsc --noEmit` over the smoke script's typed imports |
| Bot routing writes one drawer per incoming Discord message in watched channels | Test 9 (transcribeIncoming dedupe across multiple BotInstances seeing the same MessageCreate); production wiring in `BotInstance.handleMessage` after the channel allowlist filter |
| Bot routing writes one drawer per outgoing reply with the bot's own author identity. Claude async-reply path also captured | Test 10 (sender hook + sibling-incoming hook both call `transcribeIncoming` with the same `sent.id` → exactly one drawer); production wiring in `sendOrAttach` and `sendWithFiles` |
| After 501st write, oldest drawer for that channel is removed atomically | Test 2 (600 writes → exactly 500 remain, oldest evicted, newest retained) + Test 11 (per-channel mutex; no two writes overlap their cap-enforcement critical sections) |
| No byte cap; oversize messages filtered upstream | No byte-cap code path in module — only the 500-count cap exists. Filtering is upstream slice #5's job |
| `readVerbatimWindow` returns most-recent K excluding `excludeAuthor`, oldest-to-newest | Test 5 (3 assertions: ordering, exclusion, exact text positions) + Test 15 (JSON-safe author with embedded quote) |
| `searchProse` calls `mpSearch` with `wing="conversation"` and applies channel scope when provided | Test 6 (6 assertions: wing arg, room arg with/without `channelId`, result counts and channel scoping) |
| Layer B fact rooms unaffected by the cap | Test 3 (writes 12 Layer B drawers + 501 transcript drawers; asserts all 12 survive while only 500 transcript drawers remain) |
| Robustness under preview truncation / malformed envelopes / >CAP*2+1 backlog / soft delete failures | Tests 12, 13, 14, 17, 18 |
| `package.json` script `smoketest:channel-transcript` invokes the new test | Added |
| Module is a no-op when `MEMPALACE_ENABLED=false` (including no LRU mutation) | Test 7 + Test 19 (an id observed while disabled stays eligible after re-enable) |

Per-channel scope of the cap is also explicitly tested (Test 4): 100 writes to channel B + 600 to channel A leaves B at 100 and A at 500.

## Backend-failure handling

`writeTurn` / `readVerbatimWindow` / `searchProse` log and swallow exceptions raised by the backend (Test 8). `enforceCap` checks `deleteDrawer`'s boolean return and logs each `false` (the default mempalace client returns `false` on soft HTTP failures without throwing). The "MemPalace offline" warning is the integration point this slice exposes for slice #8 — that's where the user-visible warning logic lands.

## Test plan

- [ ] `npm run smoketest:channel-transcript` passes (53/53)
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run smoketest:sentinel` still passes (45/45)
- [ ] `npm run smoketest:truncation` still passes (5/5)
- [ ] `npm run smoketest:overlay` — pre-existing 2 failures unchanged (unrelated to this slice; confirmed against `origin/main` baseline)
- [ ] Manual: with `MEMPALACE_ENABLED=true` and a live MemPalace, send a Discord message in a watched channel and confirm a drawer appears in `wing="conversation"`, `room=<channelId>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)