### PR TITLE
chore: renumber ADR-0002 (btw side session) to ADR-0005

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -132,7 +132,7 @@ cleared. The next message in the channel falls through to the
 
 ### Side session
 The ephemeral, single-turn `Session` spawned by `/btw`. Created with a fresh
-Claude session id (no `--resume` of the channel's main session — see ADR-0002),
+Claude session id (no `--resume` of the channel's main session — see ADR-0005),
 with a prompt seeded from `fetchChannelContext(...)` plus the main session's
 `lastAssistantText` for read-only awareness of the in-flight context. Single
 turn: discarded after `complete`, not persisted to `sessions.json`. Posts to

--- a/docs/adr/0005-btw-side-session-isolation.md
+++ b/docs/adr/0005-btw-side-session-isolation.md
@@ -1,4 +1,4 @@
-# ADR-0002: `/btw` side sessions use a fresh Claude session id, not concurrent `--resume`
+# ADR-0005: `/btw` side sessions use a fresh Claude session id, not concurrent `--resume`
 
 **Status:** Accepted — 2026-05-02
 **Related:** `src/discord-bot.ts:claudeHandler`, `src/claude-runner.ts:createSession`, CONTEXT.md → "Side session"


### PR DESCRIPTION
## Summary

- Resolves the `docs/adr/` numbering collision: PR #11 (channel transcript foundation, accepted 2026-04-30) and the btw-side-session ADR (accepted 2026-05-02) both merged into main as ADR-0002.
- Convention is sequence-by-acceptance-date, so the earlier (channel transcript) keeps slot 0002 and the later (btw side session) moves to the next free slot 0005.
- Updates the only inbound reference in `CONTEXT.md` (line 135).

## Test plan

- [ ] No source code changes — \`tsc --noEmit\` and existing smoketests are unaffected.
- [ ] \`grep -rn "ADR-0002\\\\b" docs/ CONTEXT.md\` returns only references to the channel-transcript ADR.
- [ ] \`grep -rn "ADR-0005\\\\b" docs/ CONTEXT.md\` returns the renumbered file plus the new \`CONTEXT.md\` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)