### PR TITLE
mempalace: relocate deploy artifacts from dcc; bump pin 3.3.1 → 3.3.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Discord bot + Claude/Qwen orchestrator. Hosts the `ClaudeCode#1840` and Qwen Dis
 
 **External services this depends on:**
 - `dcc-canon-rag` (port 3001) — embed/search over `dcc` canon. URLs: `RAG_EMBED_URL`, `CANON_SEARCH_URL`.
-- `MemPalace` (port 8100, Spark #2) — shared cross-agent memory. Toggled by `MEMPALACE_ENABLED`.
+- `MemPalace` (port 8100, Spark #2) — shared cross-agent memory. Toggled by `MEMPALACE_ENABLED`. Deploy artifacts (api-server, deploy script, MCP proxy) live in `tools/mempalace/`; the corpus-mining script is in `dcc/tools/mempalace/mine-training-data.sh` because it's coupled to dcc's content layout. See [ADR-0006](docs/adr/0006-mempalace-deploy-artifacts-colocated-with-middleware.md).
 - Qwen vLLM (Spark #1, `QWEN_VLLM_URL`).
 - A clone of `dcolclazier/dcc` at `CLAUDE_CWD` (Claude's cwd) and `CANON_REPO_PATH` (canon worktree base). On Spark #2 this is a **sparse checkout** containing only `SPARK/training_data_truth/canon/`, `SPARK/output/canon/`, `CLAUDE.md`, `.claude/`.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -132,7 +132,7 @@ cleared. The next message in the channel falls through to the
 
 ### Side session
 The ephemeral, single-turn `Session` spawned by `/btw`. Created with a fresh
-Claude session id (no `--resume` of the channel's main session — see ADR-0002),
+Claude session id (no `--resume` of the channel's main session — see ADR-0005),
 with a prompt seeded from `fetchChannelContext(...)` plus the main session's
 `lastAssistantText` for read-only awareness of the in-flight context. Single
 turn: discarded after `complete`, not persisted to `sessions.json`. Posts to

--- a/docs/adr/0005-btw-side-session-isolation.md
+++ b/docs/adr/0005-btw-side-session-isolation.md
@@ -1,4 +1,4 @@
-# ADR-0002: `/btw` side sessions use a fresh Claude session id, not concurrent `--resume`
+# ADR-0005: `/btw` side sessions use a fresh Claude session id, not concurrent `--resume`
 
 **Status:** Accepted — 2026-05-02
 **Related:** `src/discord-bot.ts:claudeHandler`, `src/claude-runner.ts:createSession`, CONTEXT.md → "Side session"

--- a/docs/adr/0006-mempalace-deploy-artifacts-colocated-with-middleware.md
+++ b/docs/adr/0006-mempalace-deploy-artifacts-colocated-with-middleware.md
@@ -1,0 +1,30 @@
+# ADR-0006: MemPalace deploy artifacts colocated with middleware
+
+**Status:** Accepted — 2026-05-02
+
+## Context
+
+MemPalace is the shared cross-agent memory service that runs on Spark #2 at `:8100`. Its deploy artifacts (`api-server.py`, `deploy-to-spark.sh`, `mcp-proxy.py`, README) historically lived in `dcolclazier/dcc` at `tools/mempalace/` because that's where the user happened to be working when MemPalace was introduced.
+
+That placement was incidental, not architectural. After ADR-0001 extracted middleware out of `dcc`, the MemPalace deploy artifacts should have followed — they have no coupling to the Unity game project, but heavy coupling to this middleware's `mempalace-client.ts` and to the operational concerns this repo already owns (Spark deploy, systemd, cross-agent infrastructure). Leaving them in `dcc` produced surface-area drift: pin bumps, hook fixes, and protocol changes had to land in a repo whose reviewers and CI know nothing about MemPalace.
+
+A patch-bump exercise on 2026-05-02 (3.3.1 → 3.3.4) made the smell concrete — the pin lived in three places in `dcc/tools/mempalace/`, but the only consumer that actually cared about the version was this repo's HTTP client.
+
+## Decision
+
+Move `api-server.py`, `deploy-to-spark.sh`, `mcp-proxy.py`, and `README.md` to `agent-middleware/tools/mempalace/`. Leave `mine-training-data.sh` in `dcc/tools/mempalace/`.
+
+The split is deliberate: `mine-training-data.sh` rsyncs `dcc/SPARK/training_data_truth/` and runs `mempalace mine` against it. It is intrinsically coupled to `dcc`'s content layout — when `dcc` reorganizes its training corpus, that script changes. The mining surface belongs with the corpus it mines; the deploy surface belongs with the middleware it serves.
+
+## Consequences
+
+- Pin bumps and operational fixes land in this repo's review flow. Future grep-for-mempalace searches in `agent-middleware` find the deploy story instead of finding nothing.
+- Two places to look when chasing a MemPalace bug: `agent-middleware/tools/mempalace/` for serving and `dcc/tools/mempalace/mine-training-data.sh` for ingestion. Documented at the top of the README in each.
+- `mempalace-client.ts` is unaffected — it only speaks HTTP to `MEMPALACE_URL`.
+- The Spark venv at `~/mempalace/.venv/` and palace data at `~/mempalace/palace/` are unchanged by this move; only the deploy-script source location changes.
+
+## Alternatives considered
+
+- **Keep everything in `dcc`.** Simplest, but doubles down on the incidental placement and forces every MemPalace change to ship through a repo whose reviewers don't own MemPalace.
+- **Move everything (including `mine-training-data.sh`) to `agent-middleware`.** Cleaner conceptual home, but the mining script would then need to either ssh into a `dcc` checkout or hardcode paths into `dcc`. Both approaches push complexity uphill to avoid a small split that is honestly described.
+- **Move everything to a third repo `mempalace-ops`.** Overkill for ~four files; would inflate the deploy story across three repos for marginal isolation.

--- a/tools/mempalace/README.md
+++ b/tools/mempalace/README.md
@@ -1,0 +1,92 @@
+# MemPalace — Shared Agent Memory
+
+Unified memory for Claude Code, Qwen, and NemoClaw via MemPalace v3.3.4 hosted on Spark #2.
+
+## Topology
+
+```
+Spark #2 (192.168.1.8)                   WSL laptop (192.168.1.32)
+┌──────────────────────────────┐         ┌────────────────────────┐
+│  vLLM Gemma 4 :8000          │         │  Claude Code           │
+│  Middleware :3000  ◄─────────┼─────────┤  └── mcp-proxy.py      │
+│  ├── mempalace-client.ts     │         │                        │
+│  └── /api/memory/*           │         └────────────────────────┘
+│  Canon-RAG :3001             │
+│  MemPalace API :8100         │
+│  └─ ~/mempalace/             │
+│     ├── .venv/               │
+│     ├── palace/              │
+│     │  ├── chroma            │
+│     │  └── kg.sqlite         │
+│     └── training_data_truth/ │
+└──────────────────────────────┘
+```
+
+The middleware that consumes this API lives in this repo (`src/mempalace-client.ts`); canon-RAG source in `dcolclazier/dcc-canon-rag`. Both run as systemd services on Spark #2.
+
+## Wings
+
+| Wing | Source | Purpose |
+|------|--------|---------|
+| `shared` | Migrated from `facts.jsonl` + new `add_fact` writes | Cross-agent ground truth |
+| `claude` | Migrated from `~/.claude/.../memory/` + new MCP writes | Claude Code's private memory |
+| `qwen` | Migrated from `qwen-memory.db` + new `remember` writes | Qwen's per-channel context |
+| `canon` | `mempalace mine` of `training_data_truth/{canon,factions,world_spine,npc,world_bible}` | Lore reference corpus |
+| `facility_ai` | `mempalace mine` of `training_data_truth/facility_ai` | AI behavior corpus |
+
+## Files
+
+- `api-server.py` — FastAPI HTTP wrapper for MemPalace MCP tools (port 8100)
+- `mcp-proxy.py` — MCP stdio→HTTP proxy for Claude Code's native MCP integration
+- `deploy-to-spark.sh` — Full deploy: install, init, start API server, add @reboot cron
+
+`mine-training-data.sh` lives in the `dcolclazier/dcc` repo at `tools/mempalace/mine-training-data.sh` because it rsyncs and mines `dcc/SPARK/training_data_truth/` into the `canon` and `facility_ai` wings — that script is intrinsically coupled to dcc's content layout, not middleware concerns.
+
+## Operations
+
+### Initial deploy (one-time, already run)
+```bash
+# from agent-middleware repo root:
+export SSH_PASS=...
+bash tools/mempalace/deploy-to-spark.sh
+
+# then from dcc repo root, to populate canon/facility_ai wings:
+bash tools/mempalace/mine-training-data.sh
+```
+
+### Restart the API server
+```bash
+sshpass -p "$SSH_PASS" ssh bender@192.168.1.8 '
+pkill -f "venv/bin/python.*api-server.py"
+cd ~/mempalace && nohup .venv/bin/python3 api-server.py >> api-server.log 2>&1 < /dev/null & disown
+'
+```
+On reboot it auto-starts via `@reboot` cron entry.
+
+The `pkill` pattern matches the python process only — a looser pattern like `pkill -f api-server.py` will also match the wrapping SSH bash command that has `api-server.py` in its argv, killing your SSH session along with the server.
+
+### **CRITICAL**: API server cache invalidation
+ChromaDB caches its HNSW index in-process. **Any external write to the palace** (running `mempalace mine`, manual sqlite edits, etc.) requires an API server restart — otherwise search returns `Error finding id`. Writes through the API itself are safe.
+
+### Enable in middleware
+In this repo's `.env`:
+```
+MEMPALACE_ENABLED=true
+MEMPALACE_URL=http://192.168.1.8:8100
+```
+Restart the middleware service. Tool executors transparently route to MemPalace.
+
+### NemoClaw access
+Memory endpoints exposed at `http://192.168.1.8:3000/api/memory/*` (gated by `canonAuth`):
+- `POST /api/memory/search` — `{query, limit, wing, room}`
+- `POST /api/memory/store` — `{wing, room, content, source_file, added_by}`
+- `POST /api/memory/list` — `{wing, room, limit}`
+- `POST /api/memory/kg/add` — `{subject, predicate, object, valid_from}`
+- `POST /api/memory/kg/query` — `{entity, as_of, direction}`
+- `DELETE /api/memory/drawer/:id`
+
+## Wing usage guidance
+
+- `shared` — facts visible to all agents. Canonical names, project decisions, user preferences.
+- `claude` / `qwen` / `nemoclaw` — agent-private notes.
+- `canon` / `facility_ai` — read-only reference. Don't write here from agents.

--- a/tools/mempalace/api-server.py
+++ b/tools/mempalace/api-server.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""
+MemPalace HTTP API — thin FastAPI wrapper around mempalace's Python API.
+
+Runs on Spark #2 (192.168.1.8:8100) alongside the Gemma 4 vLLM server.
+All three agents (Claude Code, Qwen, NemoClaw) talk to this over HTTP.
+
+Usage:
+    pip install mempalace==3.3.4 fastapi uvicorn
+    mempalace init ~/mempalace
+    python api-server.py                          # default port 8100
+    MEMPALACE_PORT=8200 python api-server.py      # custom port
+"""
+import os
+import sys
+import logging
+from typing import Optional
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException, Depends, Header
+from pydantic import BaseModel, Field
+import uvicorn
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+PALACE_PATH = os.environ.get("MEMPALACE_PALACE_PATH", os.path.expanduser("~/mempalace/palace"))
+PORT = int(os.environ.get("MEMPALACE_PORT", "8100"))
+AUTH_TOKEN = os.environ.get("MEMPALACE_TOKEN", "")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message)s")
+log = logging.getLogger("mempalace-api")
+
+# ---------------------------------------------------------------------------
+# MemPalace singletons (initialised at startup)
+# ---------------------------------------------------------------------------
+
+_kg = None  # KnowledgeGraph instance
+_config = None  # MempalaceConfig instance
+
+
+def _ensure_palace():
+    """Verify palace exists, or give a helpful error."""
+    chroma_db = os.path.join(PALACE_PATH, "chroma.sqlite3")
+    if not os.path.isfile(chroma_db):
+        log.error(f"Palace not found at {PALACE_PATH}. Run: mempalace init <dir>")
+        sys.exit(1)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global _kg, _config
+    _ensure_palace()
+    os.environ["MEMPALACE_PALACE_PATH"] = PALACE_PATH
+
+    from mempalace.config import MempalaceConfig
+    from mempalace.knowledge_graph import KnowledgeGraph
+
+    _config = MempalaceConfig()
+    kg_path = os.path.join(_config.palace_path, "knowledge_graph.sqlite3")
+    _kg = KnowledgeGraph(db_path=kg_path)
+    log.info(f"Palace loaded from {_config.palace_path}")
+    yield
+    if _kg:
+        _kg.close()
+
+
+app = FastAPI(title="MemPalace API", version="1.0.0", lifespan=lifespan)
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+async def verify_token(authorization: Optional[str] = Header(None)):
+    if not AUTH_TOKEN:
+        return  # no auth configured
+    if not authorization or authorization.replace("Bearer ", "") != AUTH_TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid or missing token")
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class SearchRequest(BaseModel):
+    query: str
+    limit: int = Field(default=5, ge=1, le=50)
+    wing: Optional[str] = None
+    room: Optional[str] = None
+    max_distance: float = Field(default=1.5)
+    min_similarity: Optional[float] = None
+
+
+class AddDrawerRequest(BaseModel):
+    wing: str
+    room: str
+    content: str
+    source_file: Optional[str] = None
+    added_by: str = "api"
+
+
+class UpdateDrawerRequest(BaseModel):
+    drawer_id: str
+    content: Optional[str] = None
+    wing: Optional[str] = None
+    room: Optional[str] = None
+
+
+class DeleteDrawerRequest(BaseModel):
+    drawer_id: str
+
+
+class ListDrawersRequest(BaseModel):
+    wing: Optional[str] = None
+    room: Optional[str] = None
+    limit: int = Field(default=20, ge=1, le=200)
+    offset: int = Field(default=0, ge=0)
+
+
+class KgAddRequest(BaseModel):
+    subject: str
+    predicate: str
+    object: str
+    valid_from: Optional[str] = None
+    source_closet: Optional[str] = None
+
+
+class KgQueryRequest(BaseModel):
+    entity: str
+    as_of: Optional[str] = None
+    direction: str = Field(default="both")
+
+
+class KgInvalidateRequest(BaseModel):
+    subject: str
+    predicate: str
+    object: str
+    ended: Optional[str] = None
+
+
+class DiaryWriteRequest(BaseModel):
+    agent_name: str
+    entry: str
+    topic: str = "general"
+
+
+class DiaryReadRequest(BaseModel):
+    agent_name: str
+    last_n: int = Field(default=10, ge=1, le=100)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "palace_path": PALACE_PATH}
+
+
+@app.get("/status", dependencies=[Depends(verify_token)])
+async def status():
+    from mempalace.mcp_server import tool_status
+    return tool_status()
+
+
+@app.post("/search", dependencies=[Depends(verify_token)])
+async def search(req: SearchRequest):
+    from mempalace.mcp_server import tool_search
+    return tool_search(
+        query=req.query,
+        limit=req.limit,
+        wing=req.wing,
+        room=req.room,
+        max_distance=req.max_distance,
+        min_similarity=req.min_similarity,
+    )
+
+
+@app.post("/drawer", dependencies=[Depends(verify_token)])
+async def add_drawer(req: AddDrawerRequest):
+    from mempalace.mcp_server import tool_add_drawer
+    return tool_add_drawer(
+        wing=req.wing,
+        room=req.room,
+        content=req.content,
+        source_file=req.source_file,
+        added_by=req.added_by,
+    )
+
+
+@app.get("/drawer/{drawer_id}", dependencies=[Depends(verify_token)])
+async def get_drawer(drawer_id: str):
+    from mempalace.mcp_server import tool_get_drawer
+    return tool_get_drawer(drawer_id=drawer_id)
+
+
+@app.put("/drawer", dependencies=[Depends(verify_token)])
+async def update_drawer(req: UpdateDrawerRequest):
+    from mempalace.mcp_server import tool_update_drawer
+    return tool_update_drawer(
+        drawer_id=req.drawer_id,
+        content=req.content,
+        wing=req.wing,
+        room=req.room,
+    )
+
+
+@app.delete("/drawer/{drawer_id}", dependencies=[Depends(verify_token)])
+async def delete_drawer(drawer_id: str):
+    from mempalace.mcp_server import tool_delete_drawer
+    return tool_delete_drawer(drawer_id=drawer_id)
+
+
+@app.post("/drawers/list", dependencies=[Depends(verify_token)])
+async def list_drawers(req: ListDrawersRequest):
+    from mempalace.mcp_server import tool_list_drawers
+    return tool_list_drawers(
+        wing=req.wing,
+        room=req.room,
+        limit=req.limit,
+        offset=req.offset,
+    )
+
+
+@app.get("/wings", dependencies=[Depends(verify_token)])
+async def list_wings():
+    from mempalace.mcp_server import tool_list_wings
+    return tool_list_wings()
+
+
+@app.get("/rooms", dependencies=[Depends(verify_token)])
+async def list_rooms(wing: Optional[str] = None):
+    from mempalace.mcp_server import tool_list_rooms
+    return tool_list_rooms(wing=wing)
+
+
+# --- Knowledge Graph ---
+
+
+@app.post("/kg/add", dependencies=[Depends(verify_token)])
+async def kg_add(req: KgAddRequest):
+    from mempalace.mcp_server import tool_kg_add
+    return tool_kg_add(
+        subject=req.subject,
+        predicate=req.predicate,
+        object=req.object,
+        valid_from=req.valid_from,
+        source_closet=req.source_closet,
+    )
+
+
+@app.post("/kg/query", dependencies=[Depends(verify_token)])
+async def kg_query(req: KgQueryRequest):
+    from mempalace.mcp_server import tool_kg_query
+    return tool_kg_query(
+        entity=req.entity,
+        as_of=req.as_of,
+        direction=req.direction,
+    )
+
+
+@app.post("/kg/invalidate", dependencies=[Depends(verify_token)])
+async def kg_invalidate(req: KgInvalidateRequest):
+    from mempalace.mcp_server import tool_kg_invalidate
+    return tool_kg_invalidate(
+        subject=req.subject,
+        predicate=req.predicate,
+        object=req.object,
+        ended=req.ended,
+    )
+
+
+@app.get("/kg/timeline", dependencies=[Depends(verify_token)])
+async def kg_timeline(entity: Optional[str] = None):
+    from mempalace.mcp_server import tool_kg_timeline
+    return tool_kg_timeline(entity=entity)
+
+
+@app.get("/kg/stats", dependencies=[Depends(verify_token)])
+async def kg_stats():
+    from mempalace.mcp_server import tool_kg_stats
+    return tool_kg_stats()
+
+
+# --- Diary ---
+
+
+@app.post("/diary/write", dependencies=[Depends(verify_token)])
+async def diary_write(req: DiaryWriteRequest):
+    from mempalace.mcp_server import tool_diary_write
+    return tool_diary_write(
+        agent_name=req.agent_name,
+        entry=req.entry,
+        topic=req.topic,
+    )
+
+
+@app.post("/diary/read", dependencies=[Depends(verify_token)])
+async def diary_read(req: DiaryReadRequest):
+    from mempalace.mcp_server import tool_diary_read
+    return tool_diary_read(
+        agent_name=req.agent_name,
+        last_n=req.last_n,
+    )
+
+
+# --- Tunnels ---
+
+
+@app.post("/tunnels/create", dependencies=[Depends(verify_token)])
+async def create_tunnel(
+    source_wing: str,
+    source_room: str,
+    target_wing: str,
+    target_room: str,
+    label: str = "",
+):
+    from mempalace.mcp_server import tool_create_tunnel
+    return tool_create_tunnel(
+        source_wing=source_wing,
+        source_room=source_room,
+        target_wing=target_wing,
+        target_room=target_room,
+        label=label,
+    )
+
+
+@app.get("/tunnels", dependencies=[Depends(verify_token)])
+async def list_tunnels(wing: Optional[str] = None):
+    from mempalace.mcp_server import tool_list_tunnels
+    return tool_list_tunnels(wing=wing)
+
+
+# --- Dedup ---
+
+
+@app.post("/check-duplicate", dependencies=[Depends(verify_token)])
+async def check_duplicate(content: str, threshold: float = 0.9):
+    from mempalace.mcp_server import tool_check_duplicate
+    return tool_check_duplicate(content=content, threshold=threshold)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=PORT, log_level="info")

--- a/tools/mempalace/deploy-to-spark.sh
+++ b/tools/mempalace/deploy-to-spark.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Deploy MemPalace HTTP API to Spark #2 (spark-45aa, 192.168.1.8)
+#
+# Prerequisites:
+#   - SSH access: sshpass -p "$SSH_PASS" ssh bender@192.168.1.8
+#   - Python 3.9+ on Spark
+#
+# Usage (run from agent-middleware repo root):
+#   export SSH_PASS=...
+#   bash tools/mempalace/deploy-to-spark.sh
+
+set -euo pipefail
+
+SPARK_HOST="192.168.1.8"
+SPARK_USER="bender"
+REMOTE_DIR="/home/$SPARK_USER/mempalace"
+PALACE_PATH="$REMOTE_DIR/palace"
+
+if [ -z "${SSH_PASS:-}" ]; then
+    echo "ERROR: SSH_PASS not set"
+    exit 1
+fi
+
+SSH="sshpass -p $SSH_PASS ssh -o StrictHostKeyChecking=no $SPARK_USER@$SPARK_HOST"
+SCP="sshpass -p $SSH_PASS scp -o StrictHostKeyChecking=no"
+
+echo "=== Step 1: Create directories on Spark ==="
+$SSH "mkdir -p $REMOTE_DIR/palace"
+
+echo "=== Step 2: Copy API server to Spark ==="
+$SCP tools/mempalace/api-server.py $SPARK_USER@$SPARK_HOST:$REMOTE_DIR/api-server.py
+
+echo "=== Step 3: Install Python dependencies (venv) ==="
+$SSH "
+    if [ ! -d $REMOTE_DIR/.venv ]; then
+        echo 'Creating venv...'
+        python3 -m venv $REMOTE_DIR/.venv
+    fi
+    source $REMOTE_DIR/.venv/bin/activate
+    pip install --upgrade pip 2>&1 | tail -1
+    pip install mempalace==3.3.4 fastapi uvicorn 2>&1 | tail -5
+"
+
+VENV_PYTHON="$REMOTE_DIR/.venv/bin/python3"
+
+echo "=== Step 4: Initialize palace (if not already done) ==="
+$SSH "
+    export MEMPALACE_PALACE_PATH=$REMOTE_DIR/palace
+    source $REMOTE_DIR/.venv/bin/activate
+    if [ ! -f $REMOTE_DIR/palace/chroma.sqlite3 ]; then
+        echo 'Initializing palace...'
+        mkdir -p $REMOTE_DIR/palace
+        python3 -c \"
+from mempalace.config import MempalaceConfig
+from mempalace.backends.chroma import ChromaBackend
+from mempalace.knowledge_graph import KnowledgeGraph
+import os
+os.environ['MEMPALACE_PALACE_PATH'] = '$REMOTE_DIR/palace'
+c = MempalaceConfig()
+client = ChromaBackend.make_client(c.palace_path)
+col = client.get_or_create_collection('mempalace_drawers')
+kg = KnowledgeGraph(db_path=os.path.join(c.palace_path, 'knowledge_graph.sqlite3'))
+print('Palace initialized:', c.palace_path)
+print('Collection:', col.name, 'count:', col.count())
+print('KG:', kg.stats())
+kg.close()
+\"
+    else
+        echo 'Palace already exists.'
+    fi
+"
+
+echo "=== Step 5: Start API server ==="
+# pkill pattern is tight enough to NOT match the SSH bash wrapper that contains
+# "api-server.py" as an argv string. Matching "venv/bin/python.*api-server.py"
+# only kills the actual python process.
+$SSH "
+    pkill -f 'venv/bin/python.*api-server.py' 2>/dev/null || true
+    sleep 1
+
+    cd $REMOTE_DIR
+    export MEMPALACE_PALACE_PATH=$REMOTE_DIR/palace
+    export MEMPALACE_PORT=8100
+    nohup $REMOTE_DIR/.venv/bin/python3 api-server.py >> api-server.log 2>&1 < /dev/null &
+    disown
+    echo \"Started with PID \$!\"
+    sleep 5
+    curl -sf http://localhost:8100/health && echo '' || echo 'Local health check failed — check api-server.log'
+"
+
+echo "=== Step 6: Add @reboot cron entry ==="
+$SSH "
+    CRON_CMD='@reboot cd $REMOTE_DIR && MEMPALACE_PALACE_PATH=$PALACE_PATH MEMPALACE_PORT=8100 $REMOTE_DIR/.venv/bin/python3 api-server.py >> api-server.log 2>&1'
+    if crontab -l 2>/dev/null | grep -q 'api-server.py'; then
+        echo 'Cron entry already exists.'
+    else
+        (crontab -l 2>/dev/null; echo \"\$CRON_CMD\") | crontab -
+        echo 'Added @reboot cron entry.'
+    fi
+"
+
+echo "=== Step 7: Verify ==="
+echo -n "Health check: "
+curl -sf http://$SPARK_HOST:8100/health && echo "" || echo "FAILED — check logs on Spark"
+
+echo ""
+echo "=== Deploy complete ==="
+echo "MemPalace API running at http://$SPARK_HOST:8100"
+echo ""
+echo "Verify status: curl http://$SPARK_HOST:8100/status"
+echo "Mine training data into canon/facility_ai wings: bash tools/mempalace/mine-training-data.sh (in dcc repo)"

--- a/tools/mempalace/mcp-proxy.py
+++ b/tools/mempalace/mcp-proxy.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+MCP stdio→HTTP proxy for MemPalace.
+
+Claude Code speaks MCP over stdio. This proxy translates those MCP tool
+calls into HTTP requests against the MemPalace API server on Spark #2.
+
+Usage in Claude Code project settings.json:
+{
+  "mcpServers": {
+    "mempalace": {
+      "command": "python3",
+      "args": ["tools/mempalace/mcp-proxy.py", "--url", "http://192.168.1.8:8100"]
+    }
+  }
+}
+
+Requires: pip install mcp  (the Python MCP SDK)
+"""
+import argparse
+import json
+import logging
+import os
+import sys
+import urllib.request
+import urllib.error
+
+# MCP SDK (Python)
+try:
+    from mcp.server import Server
+    from mcp.server.stdio import stdio_server
+    from mcp import types
+except ImportError:
+    print("ERROR: pip install mcp", file=sys.stderr)
+    sys.exit(1)
+
+logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+log = logging.getLogger("mempalace-mcp-proxy")
+
+# ---------------------------------------------------------------------------
+# HTTP client (stdlib only — no requests dependency)
+# ---------------------------------------------------------------------------
+
+API_URL = ""
+AUTH_TOKEN = os.environ.get("MEMPALACE_TOKEN", "")
+
+
+def _api(method: str, path: str, body: dict = None) -> dict:
+    """Call the MemPalace HTTP API. Returns parsed JSON."""
+    url = f"{API_URL}{path}"
+    data = json.dumps(body).encode() if body else None
+    headers = {"Content-Type": "application/json"}
+    if AUTH_TOKEN:
+        headers["Authorization"] = f"Bearer {AUTH_TOKEN}"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode() if e.fp else str(e)
+        return {"error": f"HTTP {e.code}: {body_text}"}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# MCP Server
+# ---------------------------------------------------------------------------
+
+server = Server("mempalace-proxy")
+
+
+@server.list_tools()
+async def list_tools():
+    return [
+        types.Tool(
+            name="mempalace_search",
+            description="Search memories across the palace. Use wing/room to scope.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Search query"},
+                    "limit": {"type": "integer", "default": 5},
+                    "wing": {"type": "string", "description": "Filter by wing (agent name)"},
+                    "room": {"type": "string", "description": "Filter by room (topic)"},
+                },
+                "required": ["query"],
+            },
+        ),
+        types.Tool(
+            name="mempalace_add_drawer",
+            description="Store a memory. Use wing='shared' for cross-agent facts, wing='claude' for private.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "wing": {"type": "string", "description": "Wing name (e.g. 'shared', 'claude', 'qwen', 'nemoclaw')"},
+                    "room": {"type": "string", "description": "Room/topic (e.g. 'decisions', 'naming', 'context')"},
+                    "content": {"type": "string", "description": "Memory content"},
+                    "source_file": {"type": "string", "description": "Optional source file path"},
+                    "added_by": {"type": "string", "default": "claude"},
+                },
+                "required": ["wing", "room", "content"],
+            },
+        ),
+        types.Tool(
+            name="mempalace_get_drawer",
+            description="Retrieve a specific drawer by ID.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "drawer_id": {"type": "string"},
+                },
+                "required": ["drawer_id"],
+            },
+        ),
+        types.Tool(
+            name="mempalace_delete_drawer",
+            description="Delete a memory drawer by ID.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "drawer_id": {"type": "string"},
+                },
+                "required": ["drawer_id"],
+            },
+        ),
+        types.Tool(
+            name="mempalace_list_drawers",
+            description="List drawers in a wing/room.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "wing": {"type": "string"},
+                    "room": {"type": "string"},
+                    "limit": {"type": "integer", "default": 20},
+                },
+            },
+        ),
+        types.Tool(
+            name="mempalace_list_wings",
+            description="List all wings in the palace.",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        types.Tool(
+            name="mempalace_list_rooms",
+            description="List rooms in a wing.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "wing": {"type": "string"},
+                },
+            },
+        ),
+        types.Tool(
+            name="mempalace_kg_add",
+            description="Add a knowledge graph triple (fact with temporal validity).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "subject": {"type": "string"},
+                    "predicate": {"type": "string"},
+                    "object": {"type": "string"},
+                    "valid_from": {"type": "string", "description": "ISO date or year"},
+                },
+                "required": ["subject", "predicate", "object"],
+            },
+        ),
+        types.Tool(
+            name="mempalace_kg_query",
+            description="Query knowledge graph for an entity's relationships.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "entity": {"type": "string"},
+                    "as_of": {"type": "string"},
+                    "direction": {"type": "string", "default": "both"},
+                },
+                "required": ["entity"],
+            },
+        ),
+        types.Tool(
+            name="mempalace_diary_write",
+            description="Write a diary entry for an agent.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "agent_name": {"type": "string"},
+                    "entry": {"type": "string"},
+                    "topic": {"type": "string", "default": "general"},
+                },
+                "required": ["agent_name", "entry"],
+            },
+        ),
+        types.Tool(
+            name="mempalace_diary_read",
+            description="Read recent diary entries for an agent.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "agent_name": {"type": "string"},
+                    "last_n": {"type": "integer", "default": 10},
+                },
+                "required": ["agent_name"],
+            },
+        ),
+        types.Tool(
+            name="mempalace_status",
+            description="Get palace status and stats.",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict):
+    route_map = {
+        "mempalace_search": ("POST", "/search"),
+        "mempalace_add_drawer": ("POST", "/drawer"),
+        "mempalace_get_drawer": ("GET", "/drawer/{drawer_id}"),
+        "mempalace_delete_drawer": ("DELETE", "/drawer/{drawer_id}"),
+        "mempalace_list_drawers": ("POST", "/drawers/list"),
+        "mempalace_list_wings": ("GET", "/wings"),
+        "mempalace_list_rooms": ("GET", "/rooms"),
+        "mempalace_kg_add": ("POST", "/kg/add"),
+        "mempalace_kg_query": ("POST", "/kg/query"),
+        "mempalace_diary_write": ("POST", "/diary/write"),
+        "mempalace_diary_read": ("POST", "/diary/read"),
+        "mempalace_status": ("GET", "/status"),
+    }
+
+    if name not in route_map:
+        return [types.TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}"}))]
+
+    method, path_template = route_map[name]
+    args = dict(arguments) if arguments else {}
+
+    # Substitute path params like {drawer_id}
+    if "{drawer_id}" in path_template:
+        drawer_id = args.pop("drawer_id", "")
+        path = path_template.replace("{drawer_id}", drawer_id)
+    else:
+        path = path_template
+
+    # GET requests pass args as query params via path
+    if method == "GET" and args:
+        from urllib.parse import urlencode
+        path = f"{path}?{urlencode({k: v for k, v in args.items() if v is not None})}"
+        result = _api(method, path)
+    else:
+        result = _api(method, path, body=args if args else None)
+
+    return [types.TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+async def main():
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    parser = argparse.ArgumentParser(description="MemPalace MCP→HTTP proxy")
+    parser.add_argument("--url", default="http://192.168.1.8:8100", help="MemPalace API URL")
+    parsed = parser.parse_args()
+    API_URL = parsed.url
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- **Move** `api-server.py`, `deploy-to-spark.sh`, `mcp-proxy.py`, `README.md` from `dcc/tools/mempalace/` → `agent-middleware/tools/mempalace/`. The middleware HTTP client (`src/mempalace-client.ts`) already lives here; this PR colocates the deploy story with the only consumer that actually cares about it. `mine-training-data.sh` stays in dcc because it rsyncs and mines `dcc/SPARK/training_data_truth/`.
- **Bump pin** 3.3.1 → 3.3.4 across all three surfaces (`api-server.py:9`, `deploy-to-spark.sh:41`, `README.md:3`). The Spark venv was already bumped in-flight today (verified: `/health` ok, drawer counts identical pre/post).
- **Operational fixes** folded into `deploy-to-spark.sh`:
  - `pkill -f "venv/bin/python.*api-server.py"` instead of `pkill -f "api-server.py"` — the looser pattern matches the SSH-wrapper bash command itself and kills the SSH session before the restart finishes (hit this bug today).
  - Dropped the "Next steps" doc rot referencing three `migrate-*.py` scripts removed during the 2026-04 cutover.
- Add **ADR-0006** documenting the move + the deliberate `mine-training-data.sh` split.
- `CLAUDE.md` updated to reference the new location and ADR-0006.

## Follow-up

A separate PR in `dcolclazier/dcc` will `git rm` the moved files (`api-server.py`, `deploy-to-spark.sh`, `mcp-proxy.py`, the now-stale chunks of `README.md`) and leave only `mine-training-data.sh` + a short README pointing here. Sequencing intentional — this PR lands first so the deploy artifacts are never absent from both repos simultaneously.

## Test plan

- [x] Spark venv `pip show mempalace` returns 3.3.4
- [x] `curl http://192.168.1.8:8100/health` → `{"status":"ok",...}`
- [x] `/status` returns identical drawer counts pre/post upgrade (16384 total, all 5 wings unchanged)
- [x] `POST /search` with and without wing filter returns real results
- [ ] Re-run `bash tools/mempalace/deploy-to-spark.sh` from this repo root in a future cycle to confirm the script's relative paths still resolve (deferred — server is up and healthy now, and re-running deploy would unnecessarily bounce the API)
- [ ] After this lands: open the dcc deletion PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)