### PR TITLE
feat(qwen): topical recall via dual-wing search and last-3-user-messages query

### DIFF
--- a/REVIEW-NOTES.md
+++ b/REVIEW-NOTES.md
@@ -1,0 +1,22 @@
+## test-coverage — 2026-05-02
+
+**Critique:** `searchTopicalDecisions` (the 8-way fan-out + merge-by-similarity +
+text-dedupe helper) has no direct unit test. The smoketest verifies the query
+construction (`buildLastUserMessagesQuery`) and the block rendering
+(`buildSystemPrompt`) but does not exercise the merge/sort/dedupe logic with a
+fake `mpSearch`.
+
+**Decision:** ship despite suggestion.
+
+**Reasoning:** The harness has no injection seam for `mpSearch` today — covering
+the merge logic would require either (a) adding a `_setMpSearchForTesting` DI
+hook to the production module just for this slice, or (b) wiring a full
+integration backend test against `MEMPALACE_ENABLED=true`. Both are out of
+scope for issue #7's brief, which calls for a smoketest verifying that "the
+search query equals the concatenation of the last 3" and "the two blocks
+render with the correct content" — both covered. The merge logic itself is
+small (sort by `similarity` desc, dedupe by `text`), well-typed, and has obvious
+failure modes that would surface immediately on any real run. If a regression
+ever does land here we can revisit and add a DI seam at that point — premature
+infrastructure for a function that has not historically been a source of
+defects.

--- a/docs/agents/prior-rejected-suggestions.md
+++ b/docs/agents/prior-rejected-suggestions.md
@@ -17,3 +17,15 @@ so future-you can audit whether the rejection is still valid.
       rationale: "ADR-0003's budget table specifies the persona slot as `SOUL.md + MEMORY.md + IDENTITY.md` (per-file sum) and reserves a separate 500-token `margin` slot for tokenizer drift / formatting overhead. The drift from BPE non-additivity on natural text with whitespace separators is empirically ≤1%, inside that margin. Sum-of-parts also matches the existing test contract in scripts/test-persona-budget.ts."
       file: src/qwen-persona.ts
       line: 41
+
+- pr: 27
+  date: 2026-05-02
+  rejections:
+    - critique: "The new 8-way fan-out/merge helper (`searchTopicalDecisions`) is untested. `scripts/test-topical-recall.ts` only exercises query construction and block rendering, so regressions in the actual mpSearch merge/sort/dedupe path would still pass the added smoketest."
+      rationale: "REVIEW-NOTES.md `test-coverage — 2026-05-02` records this as a deliberate /self-review deferred decision: the harness has no DI seam for `mpSearch`, so adding direct unit coverage requires either a `_setMpSearchForTesting` hook in production code or a full integration backend test against `MEMPALACE_ENABLED=true`. Both are out of scope for issue #7's brief. Merge logic is small (sort by similarity desc + dedupe by text), well-typed, and not historically a defect source. Revisit if a regression actually lands."
+      file: src/qwen-harness.ts
+      line: 1322
+    - critique: "The non-MemPalace fallback `prose` is always empty (`prose = mpEnabled() ? searchProse(...) : []`), so when MEMPALACE_ENABLED=false the prior `readFactsAsString` shared-facts source disappears entirely. Deployments running in fallback mode lose the feature."
+      rationale: "ADR-0003's budget table replaces the prior `[SHARED FACTS]` block with `[RELEVANT PROSE]` sourced from MemPalace's `conversation` wing. The two are different data sources (durable structured facts vs per-channel transcript history); backfilling `readFactsAsString` into the prose array would conflate them under one block name. If fallback-mode shared-facts visibility is still wanted, the right fix is a separate `[SHARED FACTS]` block restoration as a follow-up — not a prose-block backfill on this PR."
+      file: src/qwen-harness.ts
+      line: 1463

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "smoketest:persona-budget": "tsx scripts/test-persona-budget.ts",
     "smoketest:oversize-turn": "tsx scripts/test-oversize-turn.ts",
     "smoketest:channel-transcript": "tsx scripts/test-channel-transcript.ts",
-    "smoketest:verbatim-window": "tsx scripts/test-verbatim-window.ts"
+    "smoketest:verbatim-window": "tsx scripts/test-verbatim-window.ts",
+    "smoketest:topical-recall": "tsx scripts/test-topical-recall.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/test-topical-recall.ts
+++ b/scripts/test-topical-recall.ts
@@ -1,0 +1,386 @@
+// Smoke tests for topical recall — last-3-user-messages query and the
+// dual-wing search rendering ([RELEVANT DECISIONS] + [RELEVANT PROSE]) in
+// the Qwen system prompt (Slice 7).
+//
+// Run: npx tsx scripts/test-topical-recall.ts
+
+import {
+  buildSystemPrompt,
+  buildLastUserMessagesQuery,
+  TOPICAL_DECISIONS_BUDGET,
+  TOPICAL_PROSE_BUDGET,
+  type QwenSession,
+} from "../src/qwen-harness.js";
+import { estimateTokens } from "../src/token-estimate.js";
+import type { TranscriptEntry } from "../src/channel-transcript.js";
+
+let failed = 0;
+let passed = 0;
+
+function check(label: string, cond: boolean, detail?: string) {
+  if (cond) {
+    console.log(`  PASS  ${label}`);
+    passed++;
+  } else {
+    console.log(`  FAIL  ${label}${detail ? " — " + detail : ""}`);
+    failed++;
+  }
+}
+
+function sect(name: string) {
+  console.log(`\n--- ${name} ---`);
+}
+
+const fakePersona = {
+  identity: "test-identity",
+  soul: "test-soul",
+  memory: "test-memory",
+};
+
+const noTools: never[] = [];
+
+function makeSession(userMessages: string[]): QwenSession {
+  // Interleave assistant messages between user messages to mimic a real turn
+  // history; the helper must filter to role=user only.
+  const messages: any[] = [];
+  for (let i = 0; i < userMessages.length; i++) {
+    messages.push({ role: "user", content: userMessages[i] });
+    messages.push({ role: "assistant", content: `assistant-reply-${i}` });
+  }
+  return {
+    id: "test-session",
+    channelId: "test-channel",
+    messages,
+    taskState: "idle",
+    currentTurn: 0,
+    toolFailures: {},
+    hadCommitDuringThisTask: false,
+    lastUserMessageRequestedCanon: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+async function main() {
+  // 1. buildLastUserMessagesQuery — concatenates last 3 by newline.
+  sect("1. buildLastUserMessagesQuery — last 3 user messages, newline-joined");
+  {
+    const session = makeSession([
+      "first user message",
+      "second user message",
+      "third user message",
+      "fourth user message",
+      "fifth user message",
+    ]);
+    const q = buildLastUserMessagesQuery(session, 3);
+    check(
+      "query equals concatenation of last 3 user messages joined by newline",
+      q === "third user message\nfourth user message\nfifth user message",
+      `got: ${JSON.stringify(q)}`,
+    );
+  }
+
+  // 2. Fewer-than-n user messages — return whatever exists, joined.
+  sect("2. fewer-than-n — joins what exists");
+  {
+    const sessionTwo = makeSession(["hello", "world"]);
+    const qTwo = buildLastUserMessagesQuery(sessionTwo, 3);
+    check(
+      "with 2 user messages and n=3, returns 'hello\\nworld'",
+      qTwo === "hello\nworld",
+      `got: ${JSON.stringify(qTwo)}`,
+    );
+
+    const sessionOne = makeSession(["only"]);
+    const qOne = buildLastUserMessagesQuery(sessionOne, 3);
+    check(
+      "with 1 user message and n=3, returns 'only'",
+      qOne === "only",
+      `got: ${JSON.stringify(qOne)}`,
+    );
+
+    const sessionEmpty: QwenSession = {
+      id: "x",
+      channelId: "x",
+      messages: [],
+      taskState: "idle",
+      currentTurn: 0,
+      toolFailures: {},
+      hadCommitDuringThisTask: false,
+      lastUserMessageRequestedCanon: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const qEmpty = buildLastUserMessagesQuery(sessionEmpty, 3);
+    check(
+      "with no user messages, returns empty string",
+      qEmpty === "",
+      `got: ${JSON.stringify(qEmpty)}`,
+    );
+  }
+
+  // 3. Conversational-pivot pattern — last 3 still includes prior context.
+  sect("3. conversational pivot — 'ok' alone is buffered by prior 2 messages");
+  {
+    const session = makeSession([
+      "Let's plan goblin season three's bestiary entry.",
+      "I'm thinking we lean into the swarm angle for goblins.",
+      "ok",
+    ]);
+    const q = buildLastUserMessagesQuery(session, 3);
+    check(
+      "pivot 'ok' is concatenated with the two prior messages",
+      q.includes("goblin season three") &&
+        q.includes("swarm angle") &&
+        q.endsWith("\nok"),
+      `got: ${JSON.stringify(q)}`,
+    );
+    // Single-message naive query would just be "ok" — confirm we are NOT
+    // doing that.
+    check(
+      "query is NOT just the last message in isolation",
+      q !== "ok",
+    );
+  }
+
+  // 4. buildSystemPrompt renders [RELEVANT DECISIONS] block when given
+  //    decisions, omits old [RELEVANT MEMORIES] block.
+  sect("4. buildSystemPrompt renders [RELEVANT DECISIONS], omits old [RELEVANT MEMORIES]");
+  {
+    const prompt = buildSystemPrompt({
+      persona: fakePersona,
+      decisions: ["decision-A: ship slice 7", "naming-B: call it topical-recall"],
+      prose: [],
+      channelState: "",
+      tools: noTools,
+      verbatimWindow: [],
+    });
+    check(
+      "[RELEVANT DECISIONS] header present",
+      prompt.includes("[RELEVANT DECISIONS]"),
+    );
+    check(
+      "decision-A line rendered",
+      prompt.includes("decision-A: ship slice 7"),
+    );
+    check(
+      "naming-B line rendered",
+      prompt.includes("naming-B: call it topical-recall"),
+    );
+    // The old [RELEVANT MEMORIES] block must NOT appear as a section header.
+    check(
+      "no [RELEVANT MEMORIES] block-header in rendered prompt",
+      !/(^|\n\n)\[RELEVANT MEMORIES\]\n/.test(prompt),
+    );
+  }
+
+  // 5. [RELEVANT PROSE] block — entries rendered, header present.
+  sect("5. [RELEVANT PROSE] block renders prose entries");
+  {
+    const proseEntry: TranscriptEntry = {
+      channelId: "test-channel",
+      author: "Alice",
+      text: "earlier we agreed goblins use mob tactics",
+      timestamp: "2026-04-15T12:00:00Z",
+    };
+    const prompt = buildSystemPrompt({
+      persona: fakePersona,
+      decisions: [],
+      prose: [proseEntry],
+      channelState: "",
+      tools: noTools,
+      verbatimWindow: [],
+    });
+    check(
+      "[RELEVANT PROSE] header present",
+      prompt.includes("[RELEVANT PROSE]"),
+    );
+    check(
+      "prose body text rendered",
+      prompt.includes("earlier we agreed goblins use mob tactics"),
+    );
+    check(
+      "prose author rendered",
+      prompt.includes("Alice"),
+    );
+  }
+
+  // 6. Empty inputs → both blocks omitted entirely (no empty headers).
+  sect("6. empty decisions/prose → blocks omitted");
+  {
+    const prompt = buildSystemPrompt({
+      persona: fakePersona,
+      decisions: [],
+      prose: [],
+      channelState: "",
+      tools: noTools,
+      verbatimWindow: [],
+    });
+    check(
+      "no [RELEVANT DECISIONS] block-header when decisions empty",
+      !/(^|\n\n)\[RELEVANT DECISIONS\]\n/.test(prompt),
+    );
+    check(
+      "no [RELEVANT PROSE] block-header when prose empty",
+      !/(^|\n\n)\[RELEVANT PROSE\]\n/.test(prompt),
+    );
+  }
+
+  // 7. Each block trimmed to its sub-budget.
+  sect("7. blocks trim to TOPICAL_DECISIONS_BUDGET / TOPICAL_PROSE_BUDGET");
+  {
+    // Each decision ~700 chars ≈ 200 tokens. 10 of them ≈ 2000 tokens — over
+    // the 1500-token budget, so trimming must drop at least the last few.
+    const med = "x ".repeat(350);
+    const decisions: string[] = [];
+    for (let i = 0; i < 10; i++) decisions.push(`d${i}: ${med}`);
+
+    const prompt = buildSystemPrompt({
+      persona: fakePersona,
+      decisions,
+      prose: [],
+      channelState: "",
+      tools: noTools,
+      verbatimWindow: [],
+    });
+    const headerIdx = prompt.indexOf("[RELEVANT DECISIONS]");
+    check(
+      "[RELEVANT DECISIONS] block rendered (not entirely dropped)",
+      headerIdx >= 0,
+    );
+    const after = prompt.slice(headerIdx);
+    const blank = after.indexOf("\n\n");
+    const block = blank >= 0 ? after.slice(0, blank) : after;
+    const blockTokens = estimateTokens(block);
+    check(
+      `decisions block tokens (${blockTokens}) ≤ TOPICAL_DECISIONS_BUDGET (${TOPICAL_DECISIONS_BUDGET})`,
+      blockTokens <= TOPICAL_DECISIONS_BUDGET,
+    );
+    // Confirm trimming actually occurred — the last entry must be dropped.
+    check(
+      "last (over-budget) decision is trimmed away",
+      !block.includes("d9:"),
+    );
+    // First entry survives (drop-from-end policy).
+    check(
+      "first decision is retained",
+      block.includes("d0:"),
+    );
+  }
+  {
+    // Prose: ~250-char entries ≈ 70 tokens each. 10 of them ≈ 700 tokens —
+    // over the 500-token budget so some must be dropped.
+    const small = "y ".repeat(120);
+    const prose: TranscriptEntry[] = [];
+    for (let i = 0; i < 10; i++) {
+      prose.push({
+        channelId: "ch",
+        author: `Author${i}`,
+        text: `${small} #${i}`,
+        timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+      });
+    }
+    const prompt = buildSystemPrompt({
+      persona: fakePersona,
+      decisions: [],
+      prose,
+      channelState: "",
+      tools: noTools,
+      verbatimWindow: [],
+    });
+    const headerIdx = prompt.indexOf("[RELEVANT PROSE]");
+    check(
+      "[RELEVANT PROSE] block rendered (not entirely dropped)",
+      headerIdx >= 0,
+    );
+    const after = prompt.slice(headerIdx);
+    const blank = after.indexOf("\n\n");
+    const block = blank >= 0 ? after.slice(0, blank) : after;
+    const blockTokens = estimateTokens(block);
+    check(
+      `prose block tokens (${blockTokens}) ≤ TOPICAL_PROSE_BUDGET (${TOPICAL_PROSE_BUDGET})`,
+      blockTokens <= TOPICAL_PROSE_BUDGET,
+    );
+    check(
+      "first prose entry (Author0) is retained",
+      block.includes("Author0:"),
+    );
+    check(
+      "last prose entry (Author9) is trimmed away",
+      !block.includes("Author9:"),
+    );
+  }
+
+  // 8a. Five-user-message scenario — query is the last 3, NOT the last 1.
+  sect("8a. five user messages → search query is concat of last 3 (not last 1)");
+  {
+    const session = makeSession([
+      "decisions about the goblin bestiary entry",
+      "let's say goblins are mob-tactics specialists",
+      "and they prefer night ambushes over day raids",
+      "ok",
+      "yes",
+    ]);
+    const q = buildLastUserMessagesQuery(session, 3);
+    // Query must include the topical context that drove "ok"/"yes".
+    check(
+      "query contains topical context (night ambushes)",
+      q.includes("night ambushes"),
+    );
+    check(
+      "query ends with the conversational pivots in order",
+      q.endsWith("ok\nyes"),
+    );
+    // The single-message naive query would fail topical recall (just "yes")
+    // — confirm the helper returns a multi-line concat instead.
+    const lines = q.split("\n");
+    check(
+      "query has exactly 3 lines (last 3 user messages)",
+      lines.length === 3,
+      `got ${lines.length}`,
+    );
+  }
+
+  // 8. Both blocks render side-by-side correctly.
+  sect("8. dual-wing — both [RELEVANT DECISIONS] and [RELEVANT PROSE] render together");
+  {
+    const proseEntry: TranscriptEntry = {
+      channelId: "test-channel",
+      author: "Bob",
+      text: "bob's earlier note about cats",
+      timestamp: "2026-04-20T09:00:00Z",
+    };
+    const prompt = buildSystemPrompt({
+      persona: fakePersona,
+      decisions: ["dec-1: cats are felines"],
+      prose: [proseEntry],
+      channelState: "",
+      tools: noTools,
+      verbatimWindow: [],
+    });
+    check(
+      "[RELEVANT DECISIONS] header present",
+      prompt.includes("[RELEVANT DECISIONS]"),
+    );
+    check(
+      "[RELEVANT PROSE] header present",
+      prompt.includes("[RELEVANT PROSE]"),
+    );
+    check(
+      "decision content rendered",
+      prompt.includes("dec-1: cats are felines"),
+    );
+    check(
+      "prose content rendered",
+      prompt.includes("bob's earlier note about cats"),
+    );
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("test-topical-recall failed:", err);
+  process.exit(1);
+});

--- a/scripts/test-verbatim-window.ts
+++ b/scripts/test-verbatim-window.ts
@@ -129,8 +129,8 @@ async function main() {
   {
     const prompt = buildSystemPrompt({
       persona: fakePersona,
-      memories: [],
-      facts: "",
+      decisions: [],
+      prose: [],
       channelState: "",
       tools: noTools,
       verbatimWindow: [],
@@ -154,8 +154,8 @@ async function main() {
     ];
     const prompt = buildSystemPrompt({
       persona: fakePersona,
-      memories: [],
-      facts: "",
+      decisions: [],
+      prose: [],
       channelState: "",
       tools: noTools,
       verbatimWindow: entries,
@@ -208,8 +208,8 @@ async function main() {
     }
     const prompt = buildSystemPrompt({
       persona: fakePersona,
-      memories: [],
-      facts: "",
+      decisions: [],
+      prose: [],
       channelState: "",
       tools: noTools,
       verbatimWindow: entries,
@@ -288,8 +288,8 @@ async function main() {
 
     const prompt = buildSystemPrompt({
       persona: fakePersona,
-      memories: [],
-      facts: "",
+      decisions: [],
+      prose: [],
       channelState: "",
       tools: noTools,
       verbatimWindow: window,
@@ -337,8 +337,8 @@ async function main() {
     check("readVerbatimWindow returned []", window.length === 0);
     const prompt = buildSystemPrompt({
       persona: fakePersona,
-      memories: [],
-      facts: "",
+      decisions: [],
+      prose: [],
       channelState: "",
       tools: noTools,
       verbatimWindow: window,
@@ -351,21 +351,23 @@ async function main() {
   }
 
   // 6. Existing system-prompt blocks are untouched by this slice.
+  // Note: [RELEVANT MEMORIES] / [SHARED FACTS] were replaced by
+  // [RELEVANT DECISIONS] / [RELEVANT PROSE] in slice #7; the assertions
+  // here only cover blocks that survive both slices.
   sect("6. existing blocks unchanged");
   {
     const prompt = buildSystemPrompt({
       persona: fakePersona,
-      memories: ["recall-A"],
-      facts: "fact-line",
+      decisions: ["dec-A"],
+      prose: [],
       channelState: "current-task: x",
       tools: noTools,
       verbatimWindow: [],
     });
     check("[CHANNEL STATE] block still rendered", prompt.includes("[CHANNEL STATE]"));
-    check("[SHARED FACTS] block still rendered", prompt.includes("[SHARED FACTS]"));
     check(
-      "[RELEVANT MEMORIES] block still rendered",
-      prompt.includes("[RELEVANT MEMORIES]"),
+      "[RELEVANT DECISIONS] block rendered when decisions provided",
+      prompt.includes("[RELEVANT DECISIONS]"),
     );
   }
 
@@ -383,8 +385,8 @@ async function main() {
     ];
     const prompt = buildSystemPrompt({
       persona: fakePersona,
-      memories: [],
-      facts: "",
+      decisions: [],
+      prose: [],
       channelState: "",
       tools: noTools,
       verbatimWindow: entries,
@@ -411,8 +413,8 @@ async function main() {
   {
     const prompt = buildSystemPrompt({
       persona: fakePersona,
-      memories: [],
-      facts: "",
+      decisions: [],
+      prose: [],
       channelState: "",
       tools: noTools,
       verbatimWindow: [],

--- a/src/qwen-harness.ts
+++ b/src/qwen-harness.ts
@@ -1333,9 +1333,14 @@ async function searchTopicalDecisions(query: string): Promise<string[]> {
       );
     }
   }
-  const settled = await Promise.all(tasks);
+  // Promise.allSettled (not all) so a single rejecting search doesn't drop
+  // results from the other 7. mpSearch currently catches its own errors and
+  // returns []; allSettled is defence-in-depth for future changes.
+  const settled = await Promise.allSettled(tasks);
   const merged: SearchResult[] = [];
-  for (const arr of settled) merged.push(...arr);
+  for (const r of settled) {
+    if (r.status === "fulfilled") merged.push(...r.value);
+  }
   merged.sort((a, b) => (b.similarity ?? 0) - (a.similarity ?? 0));
   const seen = new Set<string>();
   const out: string[] = [];

--- a/src/qwen-harness.ts
+++ b/src/qwen-harness.ts
@@ -30,19 +30,22 @@ import {
   type ToolContext,
 } from "./qwen-tools.js";
 import { recall, maybeRemember } from "./qwen-memory.js";
-import { readFactsAsString } from "./shared-facts.js";
 import {
   isEnabled as mpEnabled,
   mpSearch,
-  mpSearchAsString,
   mpAddDrawer,
   mpUpdateDrawer,
   mpGetDrawer,
   mpKgAdd,
+  type SearchResult,
 } from "./mempalace-client.js";
 import { estimateTokens } from "./token-estimate.js";
 import { loadPersona, getPersonaSync, type Persona } from "./qwen-persona.js";
-import { readVerbatimWindow, type TranscriptEntry } from "./channel-transcript.js";
+import {
+  readVerbatimWindow,
+  searchProse,
+  type TranscriptEntry,
+} from "./channel-transcript.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -128,7 +131,7 @@ const OVERLAY_SOFT_BYTES = 60_000;
 // Layer C — rolling window. After end-of-turn fact extraction (Layer B),
 // session.messages is trimmed to the most recent N user/assistant turn
 // pairs. The dropped turns live on as drawers in the qwen wing and surface
-// via mpSearch in the system prompt's [RELEVANT MEMORIES] block.
+// via mpSearch in the system prompt's [RELEVANT DECISIONS] block.
 // 10 pairs ≈ 20 messages of verbatim history; with average turn size
 // ~1500 tokens this caps the verbatim window at ~30K tokens IF tools
 // haven't been promoted out. Combined with Layer A pointer replacement,
@@ -797,20 +800,90 @@ function renderVerbatimWindowBlock(entries: TranscriptEntry[]): string {
   return "";
 }
 
+/**
+ * Render a `[RELEVANT DECISIONS]` block from durable-fact strings, trimmed
+ * to TOPICAL_DECISIONS_BUDGET tokens. Drops oldest (=last in array; callers
+ * pass decisions newest-first) entries first until it fits. Returns "" when
+ * the input is empty or every entry would have been trimmed away — callers
+ * omit the block in that case.
+ */
+function renderDecisionsBlock(decisions: string[]): string {
+  if (decisions.length === 0) return "";
+  let n = decisions.length;
+  while (n > 0) {
+    const candidate = `[RELEVANT DECISIONS]\n${decisions
+      .slice(0, n)
+      .map((d) => `- ${d}`)
+      .join("\n")}`;
+    if (estimateTokens(candidate) <= TOPICAL_DECISIONS_BUDGET) {
+      return candidate;
+    }
+    n--;
+  }
+  return "";
+}
+
+/**
+ * Render a `[RELEVANT PROSE]` block from transcript entries, trimmed to
+ * TOPICAL_PROSE_BUDGET tokens. Same oldest-first drop policy as
+ * decisions; assumes callers pass entries in the order they want preserved
+ * (search-relevance / score order). Newlines inside `entry.text` are
+ * collapsed so each entry fits on one line, mirroring the verbatim window.
+ */
+function renderProseBlock(entries: TranscriptEntry[]): string {
+  if (entries.length === 0) return "";
+  const lines = entries.map((e) => {
+    const flatText = e.text.replace(/\r?\n/g, " ");
+    return `${e.timestamp} ${e.author}: ${flatText}`;
+  });
+  let n = lines.length;
+  while (n > 0) {
+    const candidate = `[RELEVANT PROSE]\n${lines.slice(0, n).join("\n")}`;
+    if (estimateTokens(candidate) <= TOPICAL_PROSE_BUDGET) {
+      return candidate;
+    }
+    n--;
+  }
+  return "";
+}
+
+/**
+ * Build the search query used by the topical-decisions and topical-prose
+ * searches in runQwenTurn. Returns the concatenation (joined by newlines)
+ * of the last `n` user messages in `session.messages`. If fewer than `n`
+ * user messages exist, returns whatever is available; if none, "".
+ *
+ * Buffers single-message conversational pivots ("ok", "yes") against the
+ * topical context they're responding to — see issue #7.
+ */
+export function buildLastUserMessagesQuery(
+  session: QwenSession,
+  n = 3,
+): string {
+  if (n <= 0) return "";
+  const userTexts: string[] = [];
+  for (const m of session.messages) {
+    const msg = m as { role?: string; content?: unknown };
+    if (msg?.role === "user" && typeof msg.content === "string") {
+      userTexts.push(msg.content);
+    }
+  }
+  return userTexts.slice(-n).join("\n");
+}
+
 export function buildSystemPrompt(opts: {
   persona: Persona;
-  memories: string[];
-  facts: string;
+  decisions: string[];
+  prose: TranscriptEntry[];
   channelState: string;
   tools: OpenAI.Chat.Completions.ChatCompletionFunctionTool[];
   verbatimWindow: TranscriptEntry[];
 }): string {
-  const { persona, memories, facts, channelState, tools, verbatimWindow } = opts;
+  const { persona, decisions, prose, channelState, tools, verbatimWindow } =
+    opts;
 
-  const memBlock = memories.length
-    ? `[RELEVANT MEMORIES]\n${memories.map((m) => `- ${m}`).join("\n")}`
-    : "";
-  const factBlock = facts.trim() ? `[SHARED FACTS]\n${facts.trim()}` : "";
+  const decisionsBlock = renderDecisionsBlock(decisions);
+  const proseBlock = renderProseBlock(prose);
   const stateBlock = channelState.trim()
     ? `[CHANNEL STATE]\n${channelState.trim()}`
     : "";
@@ -821,13 +894,11 @@ export function buildSystemPrompt(opts: {
     .join("\n");
 
   // Layer D — layered system prompt mirroring MemPalace's L0/L1/L2/L3:
-  //   IDENTITY / VOICE / STATIC MEMORY  → L0 persona (always)
-  //   CHANNEL STATE                     → L1 channel-scoped working memory
-  //   CHANNEL CONVERSATION              → recent verbatim cross-agent recall
-  //   SHARED FACTS / RELEVANT MEMORIES  → L2 retrieval (filtered drawers)
-  //   tools + instructions              → action surface
-  // Channel state is placed near the top so it strongly anchors the model
-  // on the current task; older drawers via search appear lower-priority.
+  //   IDENTITY / VOICE / STATIC MEMORY    → L0 persona (always)
+  //   CHANNEL STATE                       → L1 channel-scoped working memory
+  //   CHANNEL CONVERSATION                → recent verbatim cross-agent recall
+  //   RELEVANT DECISIONS / RELEVANT PROSE → L2 dual-wing topical retrieval
+  //   tools + instructions                → action surface
   const instructionsBlock = `[INSTRUCTIONS]
 - Reason step by step before calling tools.
 - Call tools when you need info or to take action.
@@ -844,8 +915,8 @@ export function buildSystemPrompt(opts: {
     `[STATIC MEMORY]\n${persona.memory.trim()}`,
     stateBlock,
     conversationBlock,
-    factBlock,
-    memBlock,
+    decisionsBlock,
+    proseBlock,
     `[AVAILABLE TOOLS]\n${toolList}`,
     instructionsBlock,
   ]
@@ -1214,6 +1285,68 @@ export function validateWireBudget(
  */
 const VERBATIM_WINDOW_K = 10;
 
+/**
+ * Wings searched for topical durable decisions. Issue #7: decisions and
+ * naming live in `qwen` (per-agent fact extraction); user preferences and
+ * canon observations may also be filed under `shared` for cross-agent reach.
+ */
+const TOPICAL_DECISIONS_WINGS = ["qwen", "shared"] as const;
+
+/**
+ * Rooms searched for topical durable decisions. Issue #7: matches the
+ * Layer-B fact taxonomy in CONTEXT.md (decision / naming / user_preference /
+ * canon_observation). MemPalace's search endpoint accepts a single `room`,
+ * so we fan out one search per (wing, room) and merge by similarity.
+ */
+const TOPICAL_DECISIONS_ROOMS = [
+  "decision",
+  "naming",
+  "user_preference",
+  "canon_observation",
+] as const;
+
+/**
+ * Per-(wing,room) limit for the fan-out search. With 2 wings × 4 rooms = 8
+ * searches at limit 3 each, the merged candidate pool is up to 24 entries —
+ * downstream block rendering trims to TOPICAL_DECISIONS_BUDGET.
+ */
+const TOPICAL_DECISIONS_PER_ROOM_LIMIT = 3;
+
+/**
+ * Run the topical-decisions fan-out. Issues N searches in parallel (one per
+ * wing × room), merges their results, deduplicates by text, sorts by
+ * descending similarity, and returns the de-duped list as plain strings
+ * suitable for the `[RELEVANT DECISIONS]` block. Returns [] when MemPalace
+ * is disabled or every search fails.
+ */
+async function searchTopicalDecisions(query: string): Promise<string[]> {
+  if (!query.trim()) return [];
+  const tasks: Array<Promise<SearchResult[]>> = [];
+  for (const wing of TOPICAL_DECISIONS_WINGS) {
+    for (const room of TOPICAL_DECISIONS_ROOMS) {
+      tasks.push(
+        mpSearch(query, {
+          wing,
+          room,
+          limit: TOPICAL_DECISIONS_PER_ROOM_LIMIT,
+        }),
+      );
+    }
+  }
+  const settled = await Promise.all(tasks);
+  const merged: SearchResult[] = [];
+  for (const arr of settled) merged.push(...arr);
+  merged.sort((a, b) => (b.similarity ?? 0) - (a.similarity ?? 0));
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const r of merged) {
+    if (seen.has(r.text)) continue;
+    seen.add(r.text);
+    out.push(r.text);
+  }
+  return out;
+}
+
 export async function runQwenTurn(
   channelId: string,
   userMessage: string,
@@ -1302,37 +1435,28 @@ export async function runQwenTurn(
           break;
         }
 
-        // Gather context: persona + shared facts + vector recall + Layer C state.
+        // Gather context: persona + dual-wing topical recall + Layer C state.
         // Budget allocation comes from ADR-0003 sub-budgets:
-        //   topical decisions   → mpSearch(qwen wing) → memories block
-        //   topical prose       → mpSearch(shared wing) → facts block
+        //   topical decisions   → mpSearch over {qwen, shared} wings,
+        //                          {decision, naming, user_preference,
+        //                          canon_observation} rooms → decisions block
+        //   topical prose       → searchProse(channelId) over conversation
+        //                          wing → prose block
         //   channel state       → loadChannelState (truncated below)
-        // Each is converted from token budget to char cap via tokensToChars.
+        // Both searches use the concatenation of the last 3 user messages
+        // as their query — buffers conversational pivots ("ok") against the
+        // topical context they're responding to (issue #7).
         const persona = await ensurePersona();
-        const memoriesCharCap = tokensToChars(TOPICAL_DECISIONS_BUDGET);
-        const memoriesRaw = mpEnabled()
-          ? (
-              await mpSearch(userMessage, { wing: "qwen", limit: 3 })
-            ).map((r) => r.text)
-          : await recall(channelId, userMessage, 3, memoriesCharCap);
-        // Cap the joined memories block to TOPICAL_DECISIONS_BUDGET-equivalent
-        // chars. We keep entries newest-first (caller's order) and stop once
-        // adding one more would overflow.
-        const memories: string[] = [];
-        let memTotal = 0;
-        for (const m of memoriesRaw) {
-          const cost = m.length + 4; // approx "- " prefix + newline
-          if (memTotal + cost > memoriesCharCap) break;
-          memories.push(m);
-          memTotal += cost;
-        }
-        const facts = mpEnabled()
-          ? await mpSearchAsString("", {
-              wing: "shared",
-              limit: 10,
-              maxChars: tokensToChars(TOPICAL_PROSE_BUDGET),
-            })
-          : await readFactsAsString(tokensToChars(TOPICAL_PROSE_BUDGET));
+        const topicalQuery = buildLastUserMessagesQuery(session, 3);
+
+        const decisions = mpEnabled()
+          ? await searchTopicalDecisions(topicalQuery)
+          : await recall(channelId, userMessage, 3, tokensToChars(TOPICAL_DECISIONS_BUDGET));
+
+        const prose = mpEnabled()
+          ? await searchProse(topicalQuery, channelId, 10)
+          : [];
+
         let channelState = await loadChannelState(session);
         // Apply CHANNEL_STATE_BUDGET cap. Truncation is fine here — the
         // markdown is auto-built each turn and the head contains the most
@@ -1343,8 +1467,8 @@ export async function runQwenTurn(
         }
         const systemPrompt = buildSystemPrompt({
           persona,
-          memories,
-          facts,
+          decisions,
+          prose,
           channelState,
           tools: TOOL_SCHEMAS,
           verbatimWindow,

--- a/src/qwen-harness.ts
+++ b/src/qwen-harness.ts
@@ -802,10 +802,12 @@ function renderVerbatimWindowBlock(entries: TranscriptEntry[]): string {
 
 /**
  * Render a `[RELEVANT DECISIONS]` block from durable-fact strings, trimmed
- * to TOPICAL_DECISIONS_BUDGET tokens. Drops oldest (=last in array; callers
- * pass decisions newest-first) entries first until it fits. Returns "" when
- * the input is empty or every entry would have been trimmed away — callers
- * omit the block in that case.
+ * to TOPICAL_DECISIONS_BUDGET tokens. Drops trailing entries first — the
+ * function is order-preserving, so callers control which entries get trimmed
+ * first by their sort order. Current caller (`searchTopicalDecisions`) sorts
+ * by descending similarity, so the lowest-scoring entries drop first.
+ * Returns "" when the input is empty or every entry would have been trimmed
+ * away — callers omit the block in that case.
  */
 function renderDecisionsBlock(decisions: string[]): string {
   if (decisions.length === 0) return "";
@@ -1293,16 +1295,20 @@ const VERBATIM_WINDOW_K = 10;
 const TOPICAL_DECISIONS_WINGS = ["qwen", "shared"] as const;
 
 /**
- * Rooms searched for topical durable decisions. Issue #7: matches the
- * Layer-B fact taxonomy in CONTEXT.md (decision / naming / user_preference /
- * canon_observation). MemPalace's search endpoint accepts a single `room`,
- * so we fan out one search per (wing, room) and merge by similarity.
+ * Rooms searched for topical durable decisions. Covers the Layer-B fact
+ * taxonomy in CONTEXT.md (decision / naming / user_preference /
+ * canon_observation) plus `context` — `runRemember`, `runAddFact`, and the
+ * auto-summary writer (qwen-harness.ts:maybeRemember) write `room: "context"`,
+ * so excluding it would leave that data unreachable from the system prompt.
+ * MemPalace's search endpoint accepts a single `room`, so we fan out one
+ * search per (wing, room) and merge by similarity.
  */
 const TOPICAL_DECISIONS_ROOMS = [
   "decision",
   "naming",
   "user_preference",
   "canon_observation",
+  "context",
 ] as const;
 
 /**
@@ -1456,7 +1462,7 @@ export async function runQwenTurn(
 
         const decisions = mpEnabled()
           ? await searchTopicalDecisions(topicalQuery)
-          : await recall(channelId, userMessage, 3, tokensToChars(TOPICAL_DECISIONS_BUDGET));
+          : await recall(channelId, topicalQuery, 3, tokensToChars(TOPICAL_DECISIONS_BUDGET));
 
         const prose = mpEnabled()
           ? await searchProse(topicalQuery, channelId, 10)


### PR DESCRIPTION
**Depends on #26 (slice 6) — PR base is `dispatch/6-channel-conversation-block`, not `main`.**

Closes #7.

## Summary

- Adds `buildLastUserMessagesQuery(session, n=3)`: concatenates the last n user messages (newline-joined) from `session.messages`. Buffers single-message conversational pivots ("ok", "yes") against the topical context they're responding to — the prior single-message query failed recall on those.
- `runQwenTurn` now performs **two** searches per turn using this query:
  - **Topical decisions** — `mpSearch` fan-out across `wing ∈ {qwen, shared}` × `room ∈ {decision, naming, user_preference, canon_observation}`, merged by descending similarity, deduped by text. Trimmed to `TOPICAL_DECISIONS_BUDGET` (1500 tokens). Renders `[RELEVANT DECISIONS]`. (`mpSearch` only accepts a single `room` today, so the harness fans out 8 parallel searches and merges.)
  - **Topical prose** — `searchProse(query, channelId, 10)` from the channel-transcript module. Trimmed to `TOPICAL_PROSE_BUDGET` (500 tokens). Renders `[RELEVANT PROSE]`.
- The old `[RELEVANT MEMORIES]` and `[SHARED FACTS]` blocks are removed; both replacements omit entirely on empty results.
- Smoketest: `scripts/test-topical-recall.ts` (also wired as `npm run smoketest:topical-recall`). Verifies the helper, fewer-than-n handling, conversational-pivot buffering, block rendering, budget trimming, and dual-block side-by-side rendering. `test-verbatim-window` (slice #6) updated to match the new `buildSystemPrompt` parameter shape.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm run smoketest:topical-recall` — 30/30 pass.
- [x] `npm run smoketest:verbatim-window` (slice #6) — 30/30 pass; `[CHANNEL CONVERSATION]` block behavior unchanged.
- [x] Other smoketests on touched files (`budget-pre-flight`, `oversize-turn`, `persona-budget`, `channel-transcript`, `sentinel-parser`) all pass; `test-truncation` and `test-overlay-budget` failures are pre-existing on the parent branch and unrelated to this slice.

## Self-review

Self-review (`auto` posture) ran one agree-and-fix commit (`Promise.allSettled` defensive change in the fan-out so a future-throwing `mpSearch` can't drop fulfilled peers). One deferred finding recorded in `REVIEW-NOTES.md`:

### test-coverage — 2026-05-02

**Critique:** `searchTopicalDecisions` (the 8-way fan-out + merge-by-similarity + text-dedupe helper) has no direct unit test. The smoketest verifies the query construction and the block rendering but does not exercise the merge/sort/dedupe logic with a fake `mpSearch`.

**Decision:** ship despite suggestion.

**Reasoning:** The harness has no injection seam for `mpSearch` today — covering the merge logic would require either (a) adding a `_setMpSearchForTesting` DI hook to the production module just for this slice, or (b) wiring a full integration backend test against `MEMPALACE_ENABLED=true`. Both are out of scope for issue #7's brief, which calls for a smoketest verifying that "the search query equals the concatenation of the last 3" and "the two blocks render with the correct content" — both covered. The merge logic itself is small (sort by `similarity` desc, dedupe by `text`), well-typed, and has obvious failure modes that would surface immediately on any real run. If a regression ever does land here we can revisit and add a DI seam at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)