### PR TITLE
issue-8: MemPalace failure-mode warning — in-channel notice once per outage

### DIFF
--- a/docs/agents/prior-rejected-suggestions.md
+++ b/docs/agents/prior-rejected-suggestions.md
@@ -17,3 +17,11 @@ so future-you can audit whether the rejection is still valid.
       rationale: "ADR-0003's budget table specifies the persona slot as `SOUL.md + MEMORY.md + IDENTITY.md` (per-file sum) and reserves a separate 500-token `margin` slot for tokenizer drift / formatting overhead. The drift from BPE non-additivity on natural text with whitespace separators is empirically ≤1%, inside that margin. Sum-of-parts also matches the existing test contract in scripts/test-persona-budget.ts."
       file: src/qwen-persona.ts
       line: 41
+
+- pr: 28
+  date: 2026-05-02
+  rejections:
+    - critique: "memoryOfflineWarned can grow without bound: once a channel has a failure and then never sees a subsequent MemPalace success, its entry is never removed. In long-lived processes that encounter many one-off channelIds during an outage, this can become an unbounded memory leak. Consider bounding this (e.g., store timestamps and periodically prune, use an LRU with a max size, or delete entries after some TTL)."
+      rationale: "Keyed by Discord channel ID, which is a stable persistent identifier — not session-scoped or ephemeral. The set's natural bound is the count of distinct Discord channels the bot ever serves (dozens), not millions of one-off keys. Per CLAUDE.md (\"Don't add features, refactor, or introduce abstractions beyond what the task requires. … Don't design for hypothetical future requirements\"), adding LRU/TTL pruning would be premature optimisation for a leak the data shape can't actually produce."
+      file: src/channel-transcript.ts
+      line: 205

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "smoketest:qwen-tools": "tsx scripts/qwen-tool-smoketest.ts",
     "smoketest:persona-budget": "tsx scripts/test-persona-budget.ts",
     "smoketest:oversize-turn": "tsx scripts/test-oversize-turn.ts",
-    "smoketest:channel-transcript": "tsx scripts/test-channel-transcript.ts"
+    "smoketest:channel-transcript": "tsx scripts/test-channel-transcript.ts",
+    "smoketest:mempalace-warning": "tsx scripts/test-mempalace-warning.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/test-channel-transcript.ts
+++ b/scripts/test-channel-transcript.ts
@@ -1383,6 +1383,89 @@ async function main() {
     _resetBackendForTesting();
   }
 
+  // 28. Memory-offline warning — notifier-throws does NOT poison the flag.
+  // Regression: if the notifier throws synchronously or its returned promise
+  // rejects (Discord outage / missing permissions), no notice was posted,
+  // so the next MemPalace failure on that channel must retry posting rather
+  // than be silenced by a flag set in advance.
+  sect("28. memory-offline warning — notifier-throws does not poison flag");
+  {
+    process.env.MEMPALACE_ENABLED = "true";
+    _resetMemoryOfflineStateForTesting();
+    _setBackendForTesting({
+      async addDrawer() {
+        return { success: false, error: "down" };
+      },
+      async listDrawers() {
+        return [];
+      },
+      async getDrawer() {
+        return null;
+      },
+      async deleteDrawer() {
+        return true;
+      },
+      async search() {
+        return [];
+      },
+    });
+
+    // Phase 1: synchronous throw. Notifier raises; no notice posted.
+    let invoked = 0;
+    setMemoryOfflineNotifier(() => {
+      invoked++;
+      throw new Error("discord down");
+    });
+    await writeTurn(channel, "A", "first", "2027-01-01T00:00:00Z");
+    check(
+      "throwing notifier was invoked on first failure",
+      invoked === 1,
+      `invoked=${invoked}`,
+    );
+
+    // Phase 2: subsequent failure on same channel — notifier must run again,
+    // because the previous attempt rolled back the flag.
+    await writeTurn(channel, "A", "second", "2027-01-01T00:00:01Z");
+    check(
+      "throwing notifier is invoked again after a prior throw",
+      invoked === 2,
+      `invoked=${invoked}`,
+    );
+
+    // Phase 3: switch to a healthy notifier; next failure must fire warning.
+    const notifications: { channelId: string; message: string }[] = [];
+    setMemoryOfflineNotifier((channelId, message) => {
+      notifications.push({ channelId, message });
+    });
+    await writeTurn(channel, "A", "third", "2027-01-01T00:00:02Z");
+    check(
+      "healthy notifier fires after prior throws unblocked the channel",
+      notifications.length === 1,
+      `actual=${notifications.length}`,
+    );
+
+    // Phase 4: async rejection. Returned promise rejects → flag should clear.
+    _resetMemoryOfflineStateForTesting();
+    let asyncInvoked = 0;
+    setMemoryOfflineNotifier(async () => {
+      asyncInvoked++;
+      throw new Error("discord rejected");
+    });
+    await writeTurn(channel, "A", "async-1", "2027-01-01T00:01:00Z");
+    // Yield to let the rejected promise's catch handler clear the flag.
+    await new Promise((r) => setTimeout(r, 10));
+    await writeTurn(channel, "A", "async-2", "2027-01-01T00:01:01Z");
+    check(
+      "async-rejecting notifier retries on next failure",
+      asyncInvoked === 2,
+      `asyncInvoked=${asyncInvoked}`,
+    );
+
+    setMemoryOfflineNotifier(null);
+    _resetMemoryOfflineStateForTesting();
+    _resetBackendForTesting();
+  }
+
   console.log(`\n======\n${passed} passed, ${failed} failed`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/scripts/test-channel-transcript.ts
+++ b/scripts/test-channel-transcript.ts
@@ -1250,6 +1250,86 @@ async function main() {
     _resetBackendForTesting();
   }
 
+  // 25. Memory-offline warning — global searchProse (no channelId) does NOT
+  // touch the per-channel offline state. There's no channel to attribute the
+  // failure to, and global searches shouldn't accidentally clear another
+  // channel's outage flag.
+  sect("25. memory-offline warning — searchProse without channelId is silent");
+  {
+    process.env.MEMPALACE_ENABLED = "true";
+    _resetMemoryOfflineStateForTesting();
+    const notifications: { channelId: string; message: string }[] = [];
+    setMemoryOfflineNotifier((channelId, message) => {
+      notifications.push({ channelId, message });
+    });
+    _setBackendForTesting({
+      async addDrawer() {
+        return { success: true, drawer_id: "x" };
+      },
+      async listDrawers() {
+        return [];
+      },
+      async getDrawer() {
+        return null;
+      },
+      async deleteDrawer() {
+        return true;
+      },
+      async search() {
+        throw new Error("global search down");
+      },
+    });
+    // Failed search WITHOUT channelId — should NOT fire warning.
+    const r = await searchProse("anything"); // no channelId
+    check("global search returned []", Array.isArray(r) && r.length === 0);
+    check(
+      "global search failure did NOT fire warning",
+      notifications.length === 0,
+      `actual=${notifications.length}`,
+    );
+    setMemoryOfflineNotifier(null);
+    _resetMemoryOfflineStateForTesting();
+    _resetBackendForTesting();
+  }
+
+  // 26. Memory-offline warning — setMemoryOfflineNotifier(null) clears the
+  // notifier; subsequent failures log but do not invoke any callback.
+  sect("26. memory-offline warning — setMemoryOfflineNotifier(null) disables");
+  {
+    process.env.MEMPALACE_ENABLED = "true";
+    _resetMemoryOfflineStateForTesting();
+    let invoked = 0;
+    setMemoryOfflineNotifier(() => {
+      invoked++;
+    });
+    setMemoryOfflineNotifier(null);
+    _setBackendForTesting({
+      async addDrawer() {
+        return { success: false, error: "down" };
+      },
+      async listDrawers() {
+        return [];
+      },
+      async getDrawer() {
+        return null;
+      },
+      async deleteDrawer() {
+        return true;
+      },
+      async search() {
+        return [];
+      },
+    });
+    await writeTurn(channel, "A", "x", "2026-12-15T00:00:00Z");
+    check(
+      "after setMemoryOfflineNotifier(null), prior callback not invoked",
+      invoked === 0,
+      `invoked=${invoked}`,
+    );
+    _resetMemoryOfflineStateForTesting();
+    _resetBackendForTesting();
+  }
+
   console.log(`\n======\n${passed} passed, ${failed} failed`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/scripts/test-channel-transcript.ts
+++ b/scripts/test-channel-transcript.ts
@@ -20,9 +20,12 @@ import {
   transcribeIncoming,
   CHANNEL_TRANSCRIPT_CAP,
   CHANNEL_TRANSCRIPT_WING,
+  MEMORY_OFFLINE_WARNING,
   _setBackendForTesting,
   _resetBackendForTesting,
   _resetSeenIncomingForTesting,
+  _resetMemoryOfflineStateForTesting,
+  setMemoryOfflineNotifier,
   type TranscriptBackend,
   type TranscriptEntry,
 } from "../src/channel-transcript.js";
@@ -914,6 +917,337 @@ async function main() {
     );
     _resetBackendForTesting();
     _resetSeenIncomingForTesting();
+  }
+
+  // 20. Memory-offline warning: failed mpAddDrawer (writeTurn) on a watched
+  // channel posts the warning ONCE. Subsequent failures while still offline
+  // do not re-fire. After a successful call, the flag clears so a fresh
+  // outage re-fires the warning.
+  sect("20. memory-offline warning — fires once per outage on writeTurn failure");
+  {
+    process.env.MEMPALACE_ENABLED = "true";
+    _resetMemoryOfflineStateForTesting();
+    const notifications: { channelId: string; message: string }[] = [];
+    setMemoryOfflineNotifier((channelId, message) => {
+      notifications.push({ channelId, message });
+    });
+    let mode: "fail" | "ok" = "fail";
+    const flippy: TranscriptBackend = {
+      async addDrawer() {
+        if (mode === "fail") return { success: false, error: "boom" };
+        return { success: true, drawer_id: "ok-1" };
+      },
+      async listDrawers() {
+        return [];
+      },
+      async getDrawer() {
+        return null;
+      },
+      async deleteDrawer() {
+        return true;
+      },
+      async search() {
+        if (mode === "fail") {
+          throw new Error("network unreachable");
+        }
+        return [];
+      },
+    };
+    _setBackendForTesting(flippy);
+
+    // First failure → notification fires.
+    await writeTurn(channel, "A", "first", "2026-10-01T00:00:00Z");
+    check(
+      "first failure posted exactly one notification",
+      notifications.length === 1,
+      `actual=${notifications.length}`,
+    );
+    check(
+      "notification carries the canonical warning text",
+      notifications[0]?.message === MEMORY_OFFLINE_WARNING,
+      `actual=${notifications[0]?.message ?? "<none>"}`,
+    );
+    check(
+      "notification is scoped to the failing channel",
+      notifications[0]?.channelId === channel,
+    );
+
+    // Second failure → flag is set, no second notification.
+    await writeTurn(channel, "A", "second", "2026-10-01T00:00:01Z");
+    check(
+      "second failure does NOT post a duplicate notification",
+      notifications.length === 1,
+      `actual=${notifications.length}`,
+    );
+
+    // Recovery → flag clears.
+    mode = "ok";
+    await writeTurn(channel, "A", "recovered", "2026-10-01T00:00:02Z");
+    check(
+      "successful call did not post a notification",
+      notifications.length === 1,
+      `actual=${notifications.length}`,
+    );
+
+    // Fresh outage → notification re-fires.
+    mode = "fail";
+    await writeTurn(channel, "A", "outage 2", "2026-10-01T00:00:03Z");
+    check(
+      "subsequent outage re-fires the notification once",
+      notifications.length === 2,
+      `actual=${notifications.length}`,
+    );
+
+    setMemoryOfflineNotifier(null);
+    _resetMemoryOfflineStateForTesting();
+    _resetBackendForTesting();
+  }
+
+  // 21. Memory-offline warning — searchProse failure on a channel-scoped call
+  // also fires the warning. Empty success (no results, but call succeeded)
+  // does NOT fire.
+  sect("21. memory-offline warning — searchProse: failure fires, empty success silent");
+  {
+    process.env.MEMPALACE_ENABLED = "true";
+    _resetMemoryOfflineStateForTesting();
+    const notifications: { channelId: string; message: string }[] = [];
+    setMemoryOfflineNotifier((channelId, message) => {
+      notifications.push({ channelId, message });
+    });
+    // Empty-success case first: backend returns [] without throwing — no warning.
+    _setBackendForTesting({
+      async addDrawer() {
+        return { success: true, drawer_id: "x" };
+      },
+      async listDrawers() {
+        return [];
+      },
+      async getDrawer() {
+        return null;
+      },
+      async deleteDrawer() {
+        return true;
+      },
+      async search() {
+        return [];
+      },
+    });
+    const empty = await searchProse("nothing matches", channel);
+    check(
+      "empty-success search returned []",
+      Array.isArray(empty) && empty.length === 0,
+    );
+    check(
+      "empty-success search did NOT fire warning",
+      notifications.length === 0,
+      `actual=${notifications.length}`,
+    );
+
+    // Failure case: backend throws — warning fires once.
+    _setBackendForTesting({
+      async addDrawer() {
+        return { success: true, drawer_id: "x" };
+      },
+      async listDrawers() {
+        return [];
+      },
+      async getDrawer() {
+        return null;
+      },
+      async deleteDrawer() {
+        return true;
+      },
+      async search() {
+        throw new Error("connect ECONNREFUSED");
+      },
+    });
+    const failed = await searchProse("anything", channel);
+    check(
+      "failed search returned []",
+      Array.isArray(failed) && failed.length === 0,
+    );
+    check(
+      "failed search fired warning once",
+      notifications.length === 1,
+      `actual=${notifications.length}`,
+    );
+    check(
+      "warning message matches canonical text",
+      notifications[0]?.message === MEMORY_OFFLINE_WARNING,
+    );
+
+    // Repeated failure on the same channel — still suppressed.
+    await searchProse("again", channel);
+    check(
+      "repeated failure on same channel suppressed",
+      notifications.length === 1,
+      `actual=${notifications.length}`,
+    );
+
+    setMemoryOfflineNotifier(null);
+    _resetMemoryOfflineStateForTesting();
+    _resetBackendForTesting();
+  }
+
+  // 22. Memory-offline warning — per-channel scoping. Channel A's outage does
+  // not suppress channel B's first-failure warning.
+  sect("22. memory-offline warning — per-channel scope");
+  {
+    process.env.MEMPALACE_ENABLED = "true";
+    _resetMemoryOfflineStateForTesting();
+    const notifications: { channelId: string; message: string }[] = [];
+    setMemoryOfflineNotifier((channelId, message) => {
+      notifications.push({ channelId, message });
+    });
+    _setBackendForTesting({
+      async addDrawer() {
+        return { success: false, error: "down" };
+      },
+      async listDrawers() {
+        return [];
+      },
+      async getDrawer() {
+        return null;
+      },
+      async deleteDrawer() {
+        return true;
+      },
+      async search() {
+        throw new Error("down");
+      },
+    });
+    await writeTurn(channel, "A", "msg-A", "2026-11-01T00:00:00Z");
+    await writeTurn(otherChannel, "B", "msg-B", "2026-11-01T00:00:01Z");
+    check(
+      "two distinct channels produced two notifications",
+      notifications.length === 2,
+      `actual=${notifications.length}`,
+    );
+    const seenChannels = new Set(notifications.map((n) => n.channelId));
+    check(
+      "notifications are per-channel",
+      seenChannels.has(channel) && seenChannels.has(otherChannel),
+    );
+    setMemoryOfflineNotifier(null);
+    _resetMemoryOfflineStateForTesting();
+    _resetBackendForTesting();
+  }
+
+  // 23. Memory-offline warning — notifier callback errors do not break the
+  // bot's reply path (writeTurn must still resolve). Defensive coding for
+  // the Discord poster failing.
+  sect("23. memory-offline warning — notifier errors swallowed");
+  {
+    process.env.MEMPALACE_ENABLED = "true";
+    _resetMemoryOfflineStateForTesting();
+    setMemoryOfflineNotifier(() => {
+      throw new Error("notifier blew up");
+    });
+    _setBackendForTesting({
+      async addDrawer() {
+        return { success: false, error: "down" };
+      },
+      async listDrawers() {
+        return [];
+      },
+      async getDrawer() {
+        return null;
+      },
+      async deleteDrawer() {
+        return true;
+      },
+      async search() {
+        return [];
+      },
+    });
+    let threw = false;
+    try {
+      await writeTurn(channel, "A", "x", "2026-12-01T00:00:00Z");
+    } catch {
+      threw = true;
+    }
+    check("writeTurn does not throw when notifier throws", !threw);
+    setMemoryOfflineNotifier(null);
+    _resetMemoryOfflineStateForTesting();
+    _resetBackendForTesting();
+  }
+
+  // 24. Memory-offline warning — backend that throws connection-style errors
+  // simulates the outage path (the real-client + unreachable-URL scenario is
+  // exercised in scripts/test-mempalace-warning.ts which spawns a fresh tsx
+  // process with MEMPALACE_URL set to a black-hole address before module
+  // load — the URL must be captured at import time, so it can't be flipped
+  // mid-run inside this script).
+  sect("24. memory-offline warning — connection-style throw simulates outage");
+  {
+    process.env.MEMPALACE_ENABLED = "true";
+    _resetMemoryOfflineStateForTesting();
+    const notifications: { channelId: string; message: string }[] = [];
+    setMemoryOfflineNotifier((channelId, message) => {
+      notifications.push({ channelId, message });
+    });
+
+    // Backend that throws the same shape mempalace-client throws when the
+    // URL is unreachable: AbortError or fetch failed, surfaced through
+    // mpSearchResult's tagged variant.
+    let outage = true;
+    _setBackendForTesting({
+      async addDrawer() {
+        if (outage) {
+          throw new Error("fetch failed: connect ECONNREFUSED 127.0.0.1:1");
+        }
+        return { success: true, drawer_id: "ok" };
+      },
+      async listDrawers() {
+        return [];
+      },
+      async getDrawer() {
+        return null;
+      },
+      async deleteDrawer() {
+        return true;
+      },
+      async search() {
+        if (outage) {
+          throw new Error("fetch failed: connect ECONNREFUSED 127.0.0.1:1");
+        }
+        return [];
+      },
+    });
+
+    const outageChannel = "outage-channel";
+    await writeTurn(outageChannel, "A", "first", "2027-01-01T00:00:00Z");
+    check(
+      "outage: first failure posts warning",
+      notifications.length === 1,
+      `actual=${notifications.length}`,
+    );
+    await writeTurn(outageChannel, "A", "second", "2027-01-01T00:00:01Z");
+    check(
+      "outage: second failure suppressed",
+      notifications.length === 1,
+      `actual=${notifications.length}`,
+    );
+    // Recovery: clear flag, no warning on success.
+    outage = false;
+    await writeTurn(outageChannel, "A", "recovered", "2027-01-01T00:00:02Z");
+    check(
+      "recovery: success does not post a notification",
+      notifications.length === 1,
+      `actual=${notifications.length}`,
+    );
+    // Fresh outage: re-fires once.
+    outage = true;
+    await writeTurn(outageChannel, "A", "outage 2", "2027-01-01T00:00:03Z");
+    check(
+      "fresh outage re-fires the warning once",
+      notifications.length === 2,
+      `actual=${notifications.length}`,
+    );
+
+    setMemoryOfflineNotifier(null);
+    _resetMemoryOfflineStateForTesting();
+    _resetBackendForTesting();
   }
 
   console.log(`\n======\n${passed} passed, ${failed} failed`);

--- a/scripts/test-channel-transcript.ts
+++ b/scripts/test-channel-transcript.ts
@@ -1330,6 +1330,59 @@ async function main() {
     _resetBackendForTesting();
   }
 
+  // 27. Memory-offline warning — failure-while-notifier-null does NOT
+  // permanently suppress later warnings once a notifier is wired. Regression
+  // test for the case where writeTurn runs (e.g. an HTTP route hits
+  // channel-transcript before Discord wiring sets the notifier): the channel
+  // must remain eligible for the first postable warning.
+  sect("27. memory-offline warning — null-notifier failure does not poison flag");
+  {
+    process.env.MEMPALACE_ENABLED = "true";
+    _resetMemoryOfflineStateForTesting();
+    setMemoryOfflineNotifier(null);
+    _setBackendForTesting({
+      async addDrawer() {
+        return { success: false, error: "down" };
+      },
+      async listDrawers() {
+        return [];
+      },
+      async getDrawer() {
+        return null;
+      },
+      async deleteDrawer() {
+        return true;
+      },
+      async search() {
+        return [];
+      },
+    });
+    // Failure occurs while no notifier is wired.
+    await writeTurn(channel, "A", "pre-wiring", "2026-12-20T00:00:00Z");
+
+    // Now the bot wiring lands — notifier is set.
+    const notifications: { channelId: string; message: string }[] = [];
+    setMemoryOfflineNotifier((channelId, message) => {
+      notifications.push({ channelId, message });
+    });
+
+    // Next failure on the same channel should fire the warning once.
+    await writeTurn(channel, "A", "post-wiring", "2026-12-20T00:00:01Z");
+    check(
+      "post-wiring failure fires warning despite earlier null-notifier failure",
+      notifications.length === 1,
+      `actual=${notifications.length}`,
+    );
+    check(
+      "warning is scoped to the channel that just failed",
+      notifications[0]?.channelId === channel,
+    );
+
+    setMemoryOfflineNotifier(null);
+    _resetMemoryOfflineStateForTesting();
+    _resetBackendForTesting();
+  }
+
   console.log(`\n======\n${passed} passed, ${failed} failed`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/scripts/test-mempalace-warning.ts
+++ b/scripts/test-mempalace-warning.ts
@@ -1,0 +1,93 @@
+// Smoke test for the issue #8 memory-offline warning, exercised against the
+// REAL mempalace-client (not the in-memory channel-transcript test backend).
+//
+// MEMPALACE_URL is captured at module-load time inside mempalace-client, so
+// the URL must be set in the environment BEFORE tsx imports the modules.
+// Run: MEMPALACE_URL=http://127.0.0.1:1 npm run smoketest:mempalace-warning
+//
+// This script forces those values in process.env at the top before any
+// channel-transcript / mempalace-client import, so it works without the
+// caller setting them.
+
+process.env.MEMPALACE_URL = "http://127.0.0.1:1"; // black-hole: always refused
+process.env.MEMPALACE_TOKEN = "";
+process.env.MEMPALACE_ENABLED = "true";
+
+const {
+  writeTurn,
+  searchProse,
+  setMemoryOfflineNotifier,
+  _resetMemoryOfflineStateForTesting,
+  MEMORY_OFFLINE_WARNING,
+} = await import("../src/channel-transcript.js");
+
+let failed = 0;
+let passed = 0;
+function check(label: string, cond: boolean, detail?: string) {
+  if (cond) {
+    console.log(`  PASS  ${label}`);
+    passed++;
+  } else {
+    console.log(`  FAIL  ${label}${detail ? " — " + detail : ""}`);
+    failed++;
+  }
+}
+
+async function main() {
+  _resetMemoryOfflineStateForTesting();
+
+  const notifications: { channelId: string; message: string }[] = [];
+  setMemoryOfflineNotifier((channelId, message) => {
+    notifications.push({ channelId, message });
+  });
+
+  const channel = "outage-real-client";
+
+  console.log(
+    "\n--- real client + unreachable URL: first writeTurn fires warning ---",
+  );
+  await writeTurn(channel, "A", "first call", "2027-02-01T00:00:00Z");
+  check(
+    "first failure produced exactly one notification",
+    notifications.length === 1,
+    `actual=${notifications.length}`,
+  );
+  check(
+    "notification carries canonical warning text",
+    notifications[0]?.message === MEMORY_OFFLINE_WARNING,
+  );
+  check(
+    "notification scoped to the failing channel",
+    notifications[0]?.channelId === channel,
+  );
+
+  console.log(
+    "\n--- second writeTurn during the same outage is suppressed ---",
+  );
+  await writeTurn(channel, "A", "second call", "2027-02-01T00:00:01Z");
+  check(
+    "second failure produced no additional notification",
+    notifications.length === 1,
+    `actual=${notifications.length}`,
+  );
+
+  console.log(
+    "\n--- searchProse against same channel during outage also suppressed ---",
+  );
+  await searchProse("anything", channel, 3);
+  check(
+    "searchProse failure suppressed (flag still set)",
+    notifications.length === 1,
+    `actual=${notifications.length}`,
+  );
+
+  setMemoryOfflineNotifier(null);
+
+  console.log(`\n======\n${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("FAIL:", err);
+  process.exit(1);
+});

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -795,7 +795,7 @@ export class BotInstance {
     try {
       const channel = await this.client.channels.fetch(channelId);
       if (!channel || !channel.isTextBased() || !("send" in channel)) return;
-      await (channel as TextChannel).send(text);
+      await channel.send(text);
     } catch (err) {
       console.error(
         `[${this.displayName}] postSystemNotice failed for channel=${channelId}: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -783,6 +783,26 @@ export class BotInstance {
 
   // --- Discord helpers ---
 
+  /**
+   * Post a short system notice (e.g. the issue #8 memory-offline warning) to
+   * a channel. Failure is non-fatal — system notices are best-effort by
+   * design. Skips transcript capture: these are infrastructure noise, not
+   * conversation, and writing them back to MemPalace during an outage would
+   * just retry the same broken connection.
+   */
+  async postSystemNotice(channelId: string, text: string): Promise<void> {
+    if (!this.client) return;
+    try {
+      const channel = await this.client.channels.fetch(channelId);
+      if (!channel || !channel.isTextBased() || !("send" in channel)) return;
+      await (channel as TextChannel).send(text);
+    } catch (err) {
+      console.error(
+        `[${this.displayName}] postSystemNotice failed for channel=${channelId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   async safeReact(channelId: string, messageId: string, emoji: string): Promise<void> {
     if (!this.client) return;
     try {

--- a/src/channel-transcript.ts
+++ b/src/channel-transcript.ts
@@ -228,15 +228,21 @@ function reportMpFailure(channelId: string, reason: string): void {
   if (memoryOfflineWarned.get(channelId) === true) return;
   const notifier = memoryOfflineNotifier;
   if (!notifier) return;
-  // Mark warned only when we actually attempt to notify. Setting the flag
-  // unconditionally would let a failure in a non-Discord context (e.g. an
-  // HTTP route hitting writeTurn before bot wiring) permanently suppress the
-  // first postable warning until a MemPalace success clears it.
+  // Mark warned only when we actually attempt to notify, and roll the flag
+  // back if the attempt fails. Setting it unconditionally would let two
+  // failure modes permanently suppress later warnings until a MemPalace
+  // success clears the flag:
+  //   (a) failure in a non-Discord context (e.g. HTTP route hits writeTurn
+  //       before bot wiring sets the notifier),
+  //   (b) the notifier itself throws/rejects (Discord outage, missing
+  //       permissions in the channel) — no notice was posted, so the next
+  //       MemPalace failure should retry posting.
   memoryOfflineWarned.set(channelId, true);
   try {
     const r = notifier(channelId, MEMORY_OFFLINE_WARNING);
     if (r && typeof (r as Promise<void>).then === "function") {
       (r as Promise<void>).catch((err: unknown) => {
+        memoryOfflineWarned.delete(channelId);
         const msg = err instanceof Error ? err.message : String(err);
         console.error(
           `[channel-transcript] memory-offline notifier rejected: ${msg}`,
@@ -244,6 +250,7 @@ function reportMpFailure(channelId: string, reason: string): void {
       });
     }
   } catch (err: unknown) {
+    memoryOfflineWarned.delete(channelId);
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[channel-transcript] memory-offline notifier threw: ${msg}`);
   }

--- a/src/channel-transcript.ts
+++ b/src/channel-transcript.ts
@@ -181,13 +181,22 @@ export function _resetBackendForTesting(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Memory-offline warning (issue #8). Channel-transcript is the single
-// integration point for MemPalace calls scoped to a Discord channel
-// (writeTurn / readVerbatimWindow / searchProse), which is why the warning
-// logic lives here rather than in mempalace-client.ts: the client speaks
-// MemPalace primitives, not channels, so it has no place to track per-channel
-// outage state. The brief authorises either location; channel-transcript is
-// preferred precisely because it already owns the channelId boundary.
+// Memory-offline warning (issue #8). Channel-transcript is the integration
+// point for MemPalace calls scoped to a Discord channel; the warning logic
+// lives here (rather than in mempalace-client.ts) because the client speaks
+// MemPalace primitives, not channels, and so has no place to track
+// per-channel outage state. The brief authorises either location;
+// channel-transcript is preferred because it already owns the channelId
+// boundary.
+//
+// Reporting points: writeTurn (failure on every Discord message routed
+// through bot-instance) and searchProse (failure on a channel-scoped
+// topical query). readVerbatimWindow does NOT report — verbatim reads
+// happen on the response path, after writeTurn has already fired the
+// warning for the same outage. Wiring reads in too would only matter for
+// the corner case of "MP went down strictly between writeTurn-success and
+// readVerbatimWindow on the same turn," and the next writeTurn/searchProse
+// would catch it. Issue #8 covers the dominant first-failure path.
 //
 // State: per-channel "warning has been posted in this outage" flag. On the
 // next successful call the flag clears so a subsequent outage re-fires once.

--- a/src/channel-transcript.ts
+++ b/src/channel-transcript.ts
@@ -226,9 +226,13 @@ function reportMpFailure(channelId: string, reason: string): void {
     `[channel-transcript] MemPalace failure for room=${channelId}: ${reason}`,
   );
   if (memoryOfflineWarned.get(channelId) === true) return;
-  memoryOfflineWarned.set(channelId, true);
   const notifier = memoryOfflineNotifier;
   if (!notifier) return;
+  // Mark warned only when we actually attempt to notify. Setting the flag
+  // unconditionally would let a failure in a non-Discord context (e.g. an
+  // HTTP route hitting writeTurn before bot wiring) permanently suppress the
+  // first postable warning until a MemPalace success clears it.
+  memoryOfflineWarned.set(channelId, true);
   try {
     const r = notifier(channelId, MEMORY_OFFLINE_WARNING);
     if (r && typeof (r as Promise<void>).then === "function") {

--- a/src/channel-transcript.ts
+++ b/src/channel-transcript.ts
@@ -43,6 +43,15 @@
  *    _resetCacheForTesting pattern from src/qwen-persona.ts introduced in
  *    PR #9). The default backend wraps mempalace-client.ts; tests substitute
  *    an in-memory backend.
+ *
+ * 6. Memory-offline warning (issue #8): a per-channel boolean tracks whether
+ *    the in-channel "memory offline" notice has already been posted in the
+ *    current outage. The first failure (mpAddDrawer/mpSearch/searchProse
+ *    via this module) fires a notifier callback once; subsequent failures
+ *    on the same channel are silent until the next successful call clears
+ *    the flag. The notifier is wired by the bot layer (see
+ *    discord-bot.ts:startDiscordBot) — channel-transcript itself has no
+ *    Discord client, so the API is callback-based.
  */
 
 import {
@@ -51,8 +60,9 @@ import {
   mpGetDrawer,
   mpListDrawers,
   mpDeleteDrawer,
-  mpSearch,
+  mpSearchResult,
   type DrawerEntry,
+  type MpResult,
   type SearchResult,
 } from "./mempalace-client.js";
 
@@ -69,6 +79,14 @@ export const CHANNEL_TRANSCRIPT_WING = "conversation";
  * messages are filtered upstream (slice #5).
  */
 export const CHANNEL_TRANSCRIPT_CAP = 500;
+
+/**
+ * Canonical in-channel notice posted on the first MemPalace failure per
+ * outage per channel. Issue #8: warn the user once that recall is offline so
+ * agents speaking past each other have an interpretable cause.
+ */
+export const MEMORY_OFFLINE_WARNING =
+  "⚠ memory offline — operating context-blind";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -107,6 +125,11 @@ export interface TranscriptBackend {
    */
   getDrawer(id: string): Promise<DrawerEntry | null>;
   deleteDrawer(id: string): Promise<boolean>;
+  /**
+   * Returns the raw search hits on success (which may be empty), or throws on
+   * timeout / network error. The throw — vs an empty array — is what lets
+   * `searchProse` distinguish "no matches" from "MemPalace down" (issue #8).
+   */
   search(
     query: string,
     opts?: { wing?: string; room?: string; limit?: number },
@@ -133,7 +156,12 @@ const defaultBackend: TranscriptBackend = {
     return mpDeleteDrawer(id);
   },
   async search(query, opts) {
-    return mpSearch(query, opts);
+    // Use the tagged-variant API so failure → throw → searchProse can fire
+    // the memory-offline warning. The plain `mpSearch` swallows errors as []
+    // and would lose the distinction (issue #8).
+    const r: MpResult<SearchResult[]> = await mpSearchResult(query, opts);
+    if (!r.ok) throw new Error(r.reason);
+    return r.value;
   },
 };
 
@@ -150,6 +178,83 @@ export function _setBackendForTesting(b: TranscriptBackend): void {
 
 export function _resetBackendForTesting(): void {
   backend = defaultBackend;
+}
+
+// ---------------------------------------------------------------------------
+// Memory-offline warning (issue #8). Channel-transcript is the single
+// integration point for MemPalace calls scoped to a Discord channel
+// (writeTurn / readVerbatimWindow / searchProse), which is why the warning
+// logic lives here rather than in mempalace-client.ts: the client speaks
+// MemPalace primitives, not channels, so it has no place to track per-channel
+// outage state. The brief authorises either location; channel-transcript is
+// preferred precisely because it already owns the channelId boundary.
+//
+// State: per-channel "warning has been posted in this outage" flag. On the
+// next successful call the flag clears so a subsequent outage re-fires once.
+// Notifier: optional callback the bot layer installs to post the in-channel
+// notice. When unset (e.g. middleware HTTP routes hit channel-transcript
+// outside a Discord context), failures are still logged but no message is
+// emitted.
+// ---------------------------------------------------------------------------
+
+export type MemoryOfflineNotifier = (
+  channelId: string,
+  message: string,
+) => void | Promise<void>;
+
+const memoryOfflineWarned = new Map<string, boolean>();
+let memoryOfflineNotifier: MemoryOfflineNotifier | null = null;
+
+export function setMemoryOfflineNotifier(n: MemoryOfflineNotifier | null): void {
+  memoryOfflineNotifier = n;
+}
+
+export function _resetMemoryOfflineStateForTesting(): void {
+  memoryOfflineWarned.clear();
+}
+
+/**
+ * Mark a MemPalace call for `channelId` as failed. If this is the FIRST
+ * failure since the last success, fires the notifier once. Subsequent
+ * failures while the flag is set are silent.
+ *
+ * Notifier errors are caught here so the bot's reply path is never broken
+ * by a Discord post failure (issue #8 acceptance: bot must still respond).
+ */
+function reportMpFailure(channelId: string, reason: string): void {
+  console.error(
+    `[channel-transcript] MemPalace failure for room=${channelId}: ${reason}`,
+  );
+  if (memoryOfflineWarned.get(channelId) === true) return;
+  memoryOfflineWarned.set(channelId, true);
+  const notifier = memoryOfflineNotifier;
+  if (!notifier) return;
+  try {
+    const r = notifier(channelId, MEMORY_OFFLINE_WARNING);
+    if (r && typeof (r as Promise<void>).then === "function") {
+      (r as Promise<void>).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(
+          `[channel-transcript] memory-offline notifier rejected: ${msg}`,
+        );
+      });
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[channel-transcript] memory-offline notifier threw: ${msg}`);
+  }
+}
+
+/**
+ * Mark a MemPalace call for `channelId` as successful. Clears the
+ * per-channel offline flag so a fresh outage re-fires the warning once.
+ * Empty-but-successful results are also "success" — only timeouts / errors
+ * trigger the warning.
+ */
+function reportMpSuccess(channelId: string): void {
+  if (memoryOfflineWarned.get(channelId) === true) {
+    memoryOfflineWarned.delete(channelId);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -330,15 +435,17 @@ export async function writeTurn(
         content,
       );
       if (!result.success) {
-        console.error(
-          `[channel-transcript] addDrawer failed for room=${channelId}: ${result.error ?? "unknown"}`,
-        );
+        // Soft failure (HTTP error caught by mempalace-client). Issue #8.
+        reportMpFailure(channelId, result.error ?? "unknown");
         return;
       }
+      // Successful write — clear any prior offline flag for this channel.
+      reportMpSuccess(channelId);
       await enforceCap(channelId);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[channel-transcript] writeTurn failed: ${msg}`);
+      reportMpFailure(channelId, msg);
     }
   });
 }
@@ -424,12 +531,15 @@ export async function searchProse(
     };
     if (channelId !== undefined) opts.room = channelId;
     const results = await backend.search(query, opts);
+    // Issue #8: empty result is a success — only the throw path is a failure.
+    if (channelId !== undefined) reportMpSuccess(channelId);
     return results
       .map(entryFromSearchResult)
       .filter((e): e is TranscriptEntry => e !== null);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[channel-transcript] searchProse failed: ${msg}`);
+    if (channelId !== undefined) reportMpFailure(channelId, msg);
     return [];
   }
 }

--- a/src/discord-bot.ts
+++ b/src/discord-bot.ts
@@ -15,6 +15,7 @@ import {
 } from "./bot-instance.js";
 import { parseSlashCommand } from "./slash-commands.js";
 import { enqueueSideTurn } from "./side-session.js";
+import { setMemoryOfflineNotifier } from "./channel-transcript.js";
 
 // --- Shared state across all bots in this process ---
 // Each BotInstance adds its own user id to this set on ClientReady so no
@@ -241,6 +242,13 @@ export async function startDiscordBot(): Promise<void> {
     return;
   }
   await claudeBot.start(token);
+  // Issue #8: route the channel-transcript memory-offline warning through the
+  // ClaudeCode bot. ClaudeCode is the bot present in every channel that
+  // routes through the channel-transcript module, so it's the natural
+  // poster. Failures are best-effort — postSystemNotice swallows them.
+  setMemoryOfflineNotifier((channelId, message) => {
+    void claudeBot.postSystemNotice(channelId, message);
+  });
 }
 
 export function isDiscordBotReady(): boolean {

--- a/src/mempalace-client.ts
+++ b/src/mempalace-client.ts
@@ -118,13 +118,25 @@ export function isEnabled(): boolean {
 // ---------------------------------------------------------------------------
 
 /**
- * Search drawers. Replaces both `recall()` (with wing="qwen") and
- * `readFactsAsString()` (with wing="shared").
+ * Tagged-variant outcome for memory-state-sensitive callers (issue #8).
+ * `mpSearch` keeps returning `T[]` for back-compat — empty array can mean
+ * either "no matches" OR "call errored and was swallowed". Callers that
+ * need to distinguish those two (channel-transcript's failure-warning
+ * logic) call `mpSearchResult` instead, which surfaces the difference.
  */
-export async function mpSearch(
+export type MpResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; reason: string };
+
+/**
+ * Search drawers (tagged-variant form). Returns `{ ok: false, reason }` on
+ * timeout or HTTP error; `{ ok: true, value: [] }` on a successful empty
+ * result. Issue #8 — used by channel-transcript to distinguish the two.
+ */
+export async function mpSearchResult(
   query: string,
   opts?: { wing?: string; room?: string; limit?: number },
-): Promise<SearchResult[]> {
+): Promise<MpResult<SearchResult[]>> {
   try {
     const resp = await api<SearchResponse>("POST", "/search", {
       query,
@@ -132,11 +144,27 @@ export async function mpSearch(
       wing: opts?.wing,
       room: opts?.room,
     });
-    return resp.results ?? [];
+    return { ok: true, value: resp.results ?? [] };
   } catch (err: any) {
-    console.error(`[mempalace] search failed: ${err?.message ?? err}`);
-    return [];
+    const reason = err?.message ?? String(err);
+    console.error(`[mempalace] search failed: ${reason}`);
+    return { ok: false, reason };
   }
+}
+
+/**
+ * Search drawers. Replaces both `recall()` (with wing="qwen") and
+ * `readFactsAsString()` (with wing="shared").
+ *
+ * Back-compat shape: returns `[]` on empty success AND on error — callers
+ * that need to tell those apart should use `mpSearchResult`.
+ */
+export async function mpSearch(
+  query: string,
+  opts?: { wing?: string; room?: string; limit?: number },
+): Promise<SearchResult[]> {
+  const r = await mpSearchResult(query, opts);
+  return r.ok ? r.value : [];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds an in-channel "⚠ memory offline — operating context-blind" notice that posts on the first MemPalace failure per outage per channel and stays silent on subsequent failures until the next successful call clears the per-channel flag, at which point a fresh outage re-fires the warning once.
- Lives in `src/channel-transcript.ts` (the natural integration point — already owns the channelId boundary). The bot layer (`src/discord-bot.ts`) installs a notifier callback that routes the warning through `claudeBot.postSystemNotice(channelId, message)` — channel-transcript itself has no Discord client, so the API is callback-based.
- Distinguishes "MemPalace returned no results" (empty success — silent) from "MemPalace timed out / errored" (failure — warning fires) by adding a tagged-variant `MpResult<T>` plus a new `mpSearchResult` function in `mempalace-client.ts`. The default `channel-transcript` backend uses the tagged form so an errored search throws inside `searchProse`, which translates that into a warning fire. `mpSearch`'s public signature is unchanged so existing callers (qwen-harness, qwen-tools, index.ts) need no edits.
- `mpAddDrawer` was already shaped as `{ success: boolean }` so no signature change there; failures (both soft `success: false` and thrown) propagate to `reportMpFailure`.
- Notifier callback errors are caught in channel-transcript so a Discord-post failure never breaks the bot's reply path.

Closes #8

## Files changed

- `src/mempalace-client.ts` — `MpResult<T>` type + `mpSearchResult` function. `mpSearch` becomes a thin adapter for back-compat.
- `src/channel-transcript.ts` — `MEMORY_OFFLINE_WARNING` constant, `MemoryOfflineNotifier` type, `setMemoryOfflineNotifier`, `_resetMemoryOfflineStateForTesting`, `reportMpFailure` / `reportMpSuccess` helpers, wiring into `writeTurn` and `searchProse`. Default-backend's `search` now uses the tagged-variant API so failures throw rather than silently returning `[]`.
- `src/bot-instance.ts` — new `postSystemNotice(channelId, text)` public method.
- `src/discord-bot.ts` — installs the notifier in `startDiscordBot()` after the Claude bot is up.
- `scripts/test-channel-transcript.ts` — 7 new sections (20–26) covering: warning fires once, suppression during outage, recovery clears flag, fresh outage re-fires, searchProse failure-vs-empty-success, per-channel scope, notifier-throws swallow, global-search silence, null-notifier disable.
- `scripts/test-mempalace-warning.ts` — new smoketest spawning a fresh tsx process against a black-hole `MEMPALACE_URL=http://127.0.0.1:1` so the real `mempalace-client.ts` is exercised end-to-end.
- `package.json` — adds `smoketest:mempalace-warning`.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm run smoketest:channel-transcript` — 75 passed, 0 failed.
- [x] `npm run smoketest:mempalace-warning` — 5 passed, 0 failed.
- [x] Pre-existing failures on `main` (`smoketest:overlay`, `smoketest:remember`, `smoketest:truncation`, `smoketest:qwen-tools`) verified identical on this branch — not regressions.
- [ ] Manual verification: stop MemPalace; send a message in a watched channel → confirm warning posts once. Send another → no second warning. Restart MemPalace; send another → silent. Stop again; next message → warning re-fires.

## Self-review

Pre-PR multi-persona review (`/self-review --posture auto`) ran and surfaced two test-coverage gaps which were applied as a follow-up commit (`c88b69f`). No deliberate disagreements requiring `REVIEW-NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)