### PR TITLE
refactor: extract wire-budget constants into shared module (#18)

### DIFF
--- a/scripts/test-oversize-turn.ts
+++ b/scripts/test-oversize-turn.ts
@@ -18,10 +18,10 @@
 
 import {
   BotInstance,
-  TURN_BUDGET,
   evaluateTurnSize,
   splitLeadingAttachmentBlocks,
 } from "../src/bot-instance.js";
+import { TURN_BUDGET } from "../src/wire-budget.js";
 import { estimateTokens } from "../src/token-estimate.js";
 
 let failed = 0;

--- a/src/bot-instance.ts
+++ b/src/bot-instance.ts
@@ -12,6 +12,7 @@ import {
 } from "./channel-transcript.js";
 
 import { estimateTokens } from "./token-estimate.js";
+import { TURN_BUDGET } from "./wire-budget.js";
 
 // --- Types ---
 
@@ -144,24 +145,6 @@ const OUTBOUND_MESSAGE_BYTE_CAP = 10_000_000;
 
 /** Max files in a single outbound message (harness contract; Discord allows up to 10). */
 const OUTBOUND_MAX_FILES_CAP = 5;
-
-// --- Oversized turn handling at the Discord routing layer ---
-//
-// Per-turn token budget enforced BEFORE the per-bot handler runs. Messages
-// over budget are either rejected (human author — ask them to chunk or attach)
-// or truncated-with-warning (bot author — keep the conversation flowing but
-// clip the body so vLLM doesn't 400). The asymmetry mirrors how
-// `parseThinkingCommand` only honours human authors.
-//
-// 22_000 from ADR-0003 (= WIRE_HARD_CAP − SYSTEM_BUDGET). src/qwen-harness.ts
-// re-derives and exports the same value under the same name. Dedupe is
-// intentionally deferred: the right fix is to lift WIRE_HARD_CAP /
-// SYSTEM_BUDGET / TURN_BUDGET into a shared constants module rather than
-// have the Discord routing layer import from a Qwen-specific module (that
-// would couple bot-instance.ts to Qwen's harness in the wrong direction).
-// Both sides agree on the value today; if ADR-0003's split changes, the
-// follow-up extraction is the place to keep them in sync.
-export const TURN_BUDGET = 22_000;
 
 /** When a bot author goes over budget, truncate to this fraction of TURN_BUDGET. */
 const TURN_TRUNCATE_FRACTION = 0.9;

--- a/src/qwen-harness.ts
+++ b/src/qwen-harness.ts
@@ -42,6 +42,13 @@ import {
 } from "./mempalace-client.js";
 import { estimateTokens } from "./token-estimate.js";
 import { loadPersona, getPersonaSync, type Persona } from "./qwen-persona.js";
+import {
+  WIRE_HARD_CAP,
+  SYSTEM_BUDGET,
+  TURN_BUDGET,
+} from "./wire-budget.js";
+
+export { WIRE_HARD_CAP, SYSTEM_BUDGET, TURN_BUDGET };
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -61,26 +68,14 @@ const PER_TOOL_FAILURE_CAP = 2;
 // Wire budget — ADR-0003 hard wire cap with system-prompt sub-budgets.
 // ---------------------------------------------------------------------------
 //
-// Replaces the earlier `CONTEXT_SOFT_LIMIT_TOKENS = 25_000` soft target which
-// also explicitly preserved the last turn group "even if it alone exceeded
-// the soft limit." That contract did not actually guarantee the user's
-// requirement of "never hit vLLM's 32k window" — large user pastes or single
-// giant tool results bypassed the cap.
-//
-// New contract:
-//   - WIRE_HARD_CAP is the absolute ceiling for any outgoing chat() request,
-//     measured AFTER overlay hydration. Compression targets TURN_BUDGET for
-//     the messages array; pre-flight refuses to send if the full request
-//     (system prompt + messages + overlay) is still over WIRE_HARD_CAP.
-//   - We preserve the last turn group up to TURN_BUDGET (not unconditionally).
-//     If after one extra compression pass the request is still over, we fail
-//     at pre-flight and return a structured `error` stop reason.
-//
-// vLLM max_model_len for Qwen3-235B = 32_768; the 2k margin between
-// WIRE_HARD_CAP and the model ceiling is tokenizer-drift insurance.
-export const WIRE_HARD_CAP = 30_000;
-export const SYSTEM_BUDGET = 8_000;
-export const TURN_BUDGET = WIRE_HARD_CAP - SYSTEM_BUDGET; // 22_000
+// WIRE_HARD_CAP / SYSTEM_BUDGET / TURN_BUDGET are defined in ./wire-budget.ts
+// (imported above and re-exported for callers like the budget pre-flight
+// smoketest). Compression targets TURN_BUDGET for the messages array;
+// pre-flight refuses to send if the full request (system prompt + messages +
+// overlay) is still over WIRE_HARD_CAP. The last turn group is preserved up
+// to TURN_BUDGET (not unconditionally) — if after one extra compression pass
+// the request is still over, we fail at pre-flight with a structured `error`
+// stop reason.
 
 // SYSTEM_BUDGET sub-allocations — sum MUST equal SYSTEM_BUDGET. See
 // docs/adr/0003-hard-wire-cap-and-system-budget.md for the rationale

--- a/src/wire-budget.ts
+++ b/src/wire-budget.ts
@@ -1,0 +1,8 @@
+// Wire-budget constants — protocol-level, shared by qwen-harness and the
+// Discord routing layer. See docs/adr/0003-hard-wire-cap-and-system-budget.md.
+//
+// vLLM max_model_len for Qwen3-235B = 32_768; the 2k margin between
+// WIRE_HARD_CAP and the model ceiling is tokenizer-drift insurance.
+export const WIRE_HARD_CAP = 30_000;
+export const SYSTEM_BUDGET = 8_000;
+export const TURN_BUDGET = WIRE_HARD_CAP - SYSTEM_BUDGET; // 22_000


### PR DESCRIPTION
## Summary

- Extract `WIRE_HARD_CAP` / `SYSTEM_BUDGET` / `TURN_BUDGET` out of `src/qwen-harness.ts` into a new leaf module `src/wire-budget.ts`. Both `qwen-harness.ts` and `bot-instance.ts` now import from it; neither owns the constants.
- Removes the parallel `TURN_BUDGET = 22_000` literal that PR #10 added to `bot-instance.ts` along with its deferred-dedupe comment block.
- `qwen-harness.ts` re-exports the three constants for backward compatibility with `scripts/test-budget-pre-flight.ts` (the only out-of-scope consumer).
- `scripts/test-oversize-turn.ts` now imports `TURN_BUDGET` directly from `src/wire-budget.ts` instead of through `bot-instance.ts`.
- Pure code-organization refactor — no value changes, no behaviour changes.

Achieves the architectural goal called out in PR #10's deferred comment: the Discord routing layer no longer reaches into a Qwen-specific module for a protocol-level constant.

Closes #18.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm run smoketest:oversize-turn` — 56 passed, 0 failed.
- [x] `npm run smoketest:budget-pre-flight` — 28 passed, 0 failed.
- [x] `npm run smoketest:persona-budget` — 9 passed, 0 failed.
- [x] Grep audit: exactly one definition site (`src/wire-budget.ts`); every other reference is an import or a re-export.

## Self-review

`/self-review --posture auto` ran the multi-persona pre-PR pass. No actionable findings — refactor is scope-aligned, type-clean, tests green, no security/correctness/test-coverage concerns. No `REVIEW-NOTES.md` needed.