### PR TITLE
docs: scaffold CHANGELOG.md with backfill of merged PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project does not yet ship versioned releases; everything sits under
+`[Unreleased]` until a tag exists.
+
+## [Unreleased]
+
+### Added
+
+- `/btw` channel slash-command — parallel side-session for "btw, quick question"
+  interjections without dropping the main turn. Capped at one in-flight per
+  channel; queued via FIFO with ⏳ reaction. ADR-0005. (#17)
+- `/cancel` and `/end` channel slash-commands — Ctrl+C / Ctrl+D analogs for the
+  channel's in-flight Claude turn. (#16)
+- Channel transcript foundation — per-channel MemPalace drawer set in
+  `wing="conversation"`, `room=<channelId>`. Each Discord message in a watched
+  channel becomes a drawer at write time; capped at 500 messages with
+  drop-oldest-on-write. Activity-bounded retention. ADR-0002, ADR-0004. (#11)
+- Hard wire cap (30 000 tokens) with explicit per-component system-prompt
+  budget (8 000 tokens, sub-allocated). Pre-flight `validateWireBudget` rejects
+  over-budget requests instead of letting vLLM 400. ADR-0003. (#12)
+- Persona startup-validation — fail-fast on over-budget personas at load time.
+  (#9)
+- Oversized-turn handling at the Discord routing layer — single human user
+  message > `TURN_BUDGET` is rejected with chunk-or-attach feedback; bot
+  messages are silently truncated with a one-line warning. (#10)
+- MemPalace failure-mode warning — in-channel notice emitted once per outage
+  when the palace is unreachable, so users know recall is degraded. (#28)
+
+### Changed
+
+- Wire-budget constants extracted into a shared module so the persona,
+  pre-flight, and compression paths import from a single source. (#29)
+- MemPalace deploy artifacts (api-server, deploy script, MCP proxy) relocated
+  from `dcc` into this repo at `tools/mempalace/`. The corpus-mining script
+  remains in `dcc/tools/mempalace/` because it's coupled to dcc's content
+  layout. ADR-0006. (#21)
+- ADR-0002 renumbered to ADR-0005 to resolve a numbering collision. (#19)


### PR DESCRIPTION
## Summary

- Scaffolds `CHANGELOG.md` (Keep-a-Changelog format) at the repo root.
- Backfills the 10 PRs already merged to `main` (Slice 1–5, /btw, /cancel+/end, MemPalace artifacts move, ADR renumber, wire-budget extract, MemPalace failure warning).
- Surfaced as J6 follow-up during `/post-merge-cleanup` on PR #27 — the repo had no CHANGELOG and seeding it now is cheaper than seeding it after the next slice merges.

PR #27 itself is not yet on `main` (it merged into the `dispatch/6-channel-conversation-block` chain) and will be added under `[Unreleased]` when that chain lands.

## Test plan

- [x] `CHANGELOG.md` reflects the actual `gh pr list --state merged --base main` set.
- [x] Format matches Keep-a-Changelog conventions (Added / Changed sections under `[Unreleased]`).
- [ ] Reviewer eyeballs the PR descriptions for any miscategorized entries (e.g. should be Fixed not Changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)