### PR TITLE
docs: fix Layer-B taxonomy drift in CONTEXT.md (`context` room)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -87,6 +87,14 @@ transcript's 500-message cap — durable facts live indefinitely until
 explicitly forgotten. The retention pathway for important decisions; channel
 transcripts are scaffolding for short-term recall.
 
+A separate `room="context"` drawer is also written by the `runRemember` /
+`runAddFact` tools (qwen-tools.ts) and the `maybeRemember` auto-summary path
+(qwen-harness.ts) — a rolling unstructured scratchpad used to seed continuity
+across turns. Same infinite-retention property as the typed rooms, but not
+part of the structured Layer-B taxonomy. Topical recall must include
+`context` in its room filter to keep this data reachable from the system
+prompt.
+
 ### RAG (canon-search RAG)
 The `dcc-canon-rag` service. Currently runs on port 3001. Provides `/embed`
 (384-dim all-MiniLM-L6-v2 vectors) and `/search` (Chroma-backed semantic search


### PR DESCRIPTION
## Summary

Surfaced as **J3** during `/post-merge-cleanup` on PR #27. The `Durable fact (Layer B fact)` glossary entry in `CONTEXT.md` was factually wrong on `main`:

- **CONTEXT.md said:** `room ∈ {decision, naming, user_preference, canon_observation}`
- **Reality on main:** three writers also write `room="context"`:
  - `runRemember` (`src/qwen-tools.ts:625`)
  - `runAddFact` (`src/qwen-tools.ts:668`)
  - `maybeRemember` auto-summary (`src/qwen-harness.ts:1660`)

Adds a paragraph describing the `context` room as a rolling unstructured scratchpad with the same infinite-retention property as the typed Layer-B taxonomy but distinct in nature. Notes that topical recall must include `context` in its room filter to keep that data reachable from the system prompt — this is what PR #27 fixes on the dispatch chain (`TOPICAL_DECISIONS_ROOMS` includes `"context"` there).

## Test plan

- [x] `git diff` shows content-only change, no line-ending noise.
- [ ] Reviewer confirms the new paragraph reads cleanly alongside the existing Layer-B entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)